### PR TITLE
[Runtime] Added large array allocation warning

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,9 @@ protected:
     return MemRegion((HeapWord*)obj, _word_size);
   }
 
+  // verify if size of allocation request satisfies certain policy
+  virtual void verify_size() const { }
+
 public:
   oop allocate() const;
   virtual oop initialize(HeapWord* mem) const = 0;
@@ -90,6 +93,7 @@ class ObjArrayAllocator: public MemAllocator {
   const bool _do_zero;
 protected:
   virtual MemRegion obj_memory_range(oop obj) const;
+  virtual void verify_size() const;
 
 public:
   ObjArrayAllocator(Klass* klass, size_t word_size, int length, bool do_zero,

--- a/src/hotspot/share/runtime/globals_ext.hpp
+++ b/src/hotspot/share/runtime/globals_ext.hpp
@@ -38,6 +38,9 @@
                          manageable,                                        \
                          product_rw,                                        \
                          lp64_product)                                      \
+  manageable(intx, ArrayAllocationWarningSize, (512*M),                     \
+             "Desired size in bytes of array space allocation before "      \
+             "printing a warning")                                          \
 //add new Dragonwell specific flags here
 
 DRAGONWELL_FLAGS(DECLARE_DEVELOPER_FLAG, DECLARE_PD_DEVELOPER_FLAG, DECLARE_PRODUCT_FLAG, \

--- a/test/hotspot/jtreg/runtime/memory/TestArrayAllocationWarning.java
+++ b/test/hotspot/jtreg/runtime/memory/TestArrayAllocationWarning.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import static jdk.test.lib.Asserts.*;
+import java.lang.management.ManagementFactory;
+import com.sun.management.HotSpotDiagnosticMXBean;
+
+/*
+ * @test
+ * @summary Test large array allocation warning "-XX:ArrayAllocationWarningSize=4M"
+ * @library /test/lib
+ * @build TestArrayAllocationWarning
+ * @run main TestArrayAllocationWarning
+ */
+public class TestArrayAllocationWarning {
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb;
+        OutputAnalyzer output;
+        String srcPath = System.getProperty("test.class.path");
+
+        pb = ProcessTools.createJavaProcessBuilder("-Xbootclasspath/a:.",
+                "-cp", ".:" + srcPath,
+                TestArrayAllocationWarningRunner.class.getName());
+        output = new OutputAnalyzer(pb.start());
+        output.shouldNotContain("==WARNING==  allocating large array--");
+        output.shouldContain("done!");
+        output.shouldHaveExitValue(0);
+        System.out.println(output.getOutput());
+
+        pb = ProcessTools.createJavaProcessBuilder("-Xbootclasspath/a:.",
+                "-cp", ".:" + srcPath,
+                TestArrayAllocationWarningRunner.class.getName(),
+                "ArrayAllocationWarningSize",
+                "4M");
+        output = new OutputAnalyzer(pb.start());
+        output.shouldContain("==WARNING==  allocating large array--");
+        output.shouldContain("done!");
+        output.shouldHaveExitValue(0);
+        System.out.println(output.getOutput());
+    }
+
+    public static class TestArrayAllocationWarningRunner {
+        public static void allocateArray(int size) {
+            Object[] array = new Object[size];
+            // avoid optimized out
+            System.out.println(array);
+        }
+        public static void main(String[] args) throws Exception {
+            if (args.length == 0) {
+                allocateArray(8 * 1000 * 1000);
+            } else {
+                assertTrue(args.length == 2);
+                String key = args[0];
+                String value = args[1].replace("M", "000000");
+                System.out.println(key);
+                System.out.println(value);
+                HotSpotDiagnosticMXBean bean = (HotSpotDiagnosticMXBean)
+                        ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+                System.out.println(bean.getVMOption(key).getValue());
+                bean.setVMOption(key, value);
+                allocateArray(8 * 1000 * 1000);
+            }
+            System.out.println("done!");
+        }
+    }
+}
+


### PR DESCRIPTION
Summary:
ported from Dragonwell 8, added new flag ArrayAllocationWarningSize
to warn allocation of large arrays

Test Plan: test/hotspot/jtreg/runtime/memory

Reviewed-by: kuaiwei

Issue: #3