### PR TITLE
[JFR] Some test failure caused by opto object allocations sampling

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -664,6 +664,15 @@
       <setting name="threshold">10 ms</setting>
     </event>
 
+    <event name="jdk.OptoInstanceObjectAllocation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.OptoArrayObjectAllocation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
 
 
 

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -664,6 +664,15 @@
       <setting name="threshold">10 ms</setting>
     </event>
 
+    <event name="jdk.OptoInstanceObjectAllocation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.OptoArrayObjectAllocation">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
 
 
 


### PR DESCRIPTION
Summary: add missing configuration to default/profile.jfc

Test Plan: test/jdk/jdk/jfr

Reviewed-by: tbzhang, luchsh

Issue: https://github.com/alibaba/dragonwell11/issues/18