### PR TITLE
[Misc] Fix build error on windows due to no precompiled header

### DIFF
--- a/src/hotspot/share/gc/shared/allocTracer.cpp
+++ b/src/hotspot/share/gc/shared/allocTracer.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "precompiled.hpp"
 #include "gc/shared/allocTracer.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "runtime/handles.hpp"

--- a/src/hotspot/share/jfr/objectprofiler/objectProfiler.cpp
+++ b/src/hotspot/share/jfr/objectprofiler/objectProfiler.cpp
@@ -19,12 +19,13 @@
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
+#include "precompiled.hpp"
 #include "runtime/vmThread.hpp"
 #include "jfr/objectprofiler/objectProfiler.hpp"
 #include "jfr/utilities/jfrTryLock.hpp"
 #include "jfr/jfrEvents.hpp"
 
-volatile jint ObjectProfiler::_enabled = JNI_FALSE;
+volatile int ObjectProfiler::_enabled = JNI_FALSE;
 bool ObjectProfiler::_sample_instance_obj_alloc  = false;
 bool ObjectProfiler::_sample_array_obj_alloc  = false;
 #ifndef PRODUCT
@@ -50,7 +51,7 @@ void ObjectProfiler::start(jlong event_id) {
   if (enabled() == JNI_TRUE) {
     return;
   }
-  OrderAccess::release_store((volatile jint*)&_enabled, JNI_TRUE);
+  OrderAccess::release_store(&_enabled, JNI_TRUE);
 }
 
 void ObjectProfiler::stop(jlong event_id) {
@@ -80,8 +81,8 @@ void ObjectProfiler::stop(jlong event_id) {
   OrderAccess::release_store(&_enabled, JNI_FALSE);
 }
 
-jint ObjectProfiler::enabled() {
-  return OrderAccess::load_acquire((volatile jint*)&_enabled);
+int ObjectProfiler::enabled() {
+  return OrderAccess::load_acquire(&_enabled);
 }
 
 void* ObjectProfiler::enabled_flag_address() {

--- a/src/hotspot/share/jfr/objectprofiler/objectProfiler.hpp
+++ b/src/hotspot/share/jfr/objectprofiler/objectProfiler.hpp
@@ -57,7 +57,7 @@
 
 class ObjectProfiler : public AllStatic {
  private:
-  static volatile jint _enabled;
+  static volatile int _enabled;
   static bool _sample_instance_obj_alloc;
   static bool _sample_array_obj_alloc;
 #ifndef PRODUCT
@@ -67,7 +67,7 @@ class ObjectProfiler : public AllStatic {
  public:
   static void start(jlong event_id);
   static void stop(jlong event_id);
-  static jint enabled();
+  static int enabled();
   static void* enabled_flag_address();
 };
 


### PR DESCRIPTION
Summary:
Dragonwell can not build on windows without precompiled header due
to dragonwell JFR commit 3471dab85033c97085cce3b731b70d455ce908c2

Reviewed-by: D-D-H,zhengxiaolinX

Test Plan: run build on adopt pipeline

Issue: https://github.com/alibaba/dragonwell11/issues/25