### PR TITLE
[Misc] fix a warning reported by GCC9

### DIFF
--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -479,7 +479,7 @@ jlong OSContainer::read_memory_limit_in_bytes() {
     log_trace(os, container)("Non-Hierarchical Memory Limit is: Unlimited");
     if (memory->is_hierarchical()) {
       const char* matchline = "hierarchical_memory_limit";
-      char* format = "%s " JULONG_FORMAT;
+      const char* format = "%s " JULONG_FORMAT;
       GET_CONTAINER_INFO_LINE(julong, memory, "/memory.stat", matchline,
                              "Hierarchical Memory Limit is: " JULONG_FORMAT, format, hier_memlimit)
       if (hier_memlimit >= _unlimited_memory) {
@@ -502,7 +502,7 @@ jlong OSContainer::memory_and_swap_limit_in_bytes() {
     log_trace(os, container)("Non-Hierarchical Memory and Swap Limit is: Unlimited");
     if (memory->is_hierarchical()) {
       const char* matchline = "hierarchical_memsw_limit";
-      char* format = "%s " JULONG_FORMAT;
+      const char* format = "%s " JULONG_FORMAT;
       GET_CONTAINER_INFO_LINE(julong, memory, "/memory.stat", matchline,
                              "Hierarchical Memory and Swap Limit is : " JULONG_FORMAT, format, hier_memlimit)
       if (hier_memlimit >= _unlimited_memory) {


### PR DESCRIPTION
Summary: Fix a warning reported by GCC9. Dragonwell can be compiled by
GCC9 after this patch.

Reviewed-by: joeyleeeeeee97, Wei Kuai

Test Plan: build test

Issue: https://github.com/alibaba/dragonwell11/issues/27