### PR TITLE
[Misc] Fix minimal build error caused by JFR

### DIFF
--- a/src/hotspot/share/gc/shared/allocTracer.hpp
+++ b/src/hotspot/share/gc/shared/allocTracer.hpp
@@ -31,16 +31,16 @@
 
 class AllocTracer : AllStatic {
   private:
-    static void send_opto_array_allocation_event(Klass* klass, oop obj,size_t alloc_size, Thread* thread);
-    static void send_opto_instance_allocation_event(Klass* klass, oop obj, Thread* thread);
+    static void send_opto_array_allocation_event(Klass* klass, oop obj,size_t alloc_size, Thread* thread) NOT_JFR_RETURN();
+    static void send_opto_instance_allocation_event(Klass* klass, oop obj, Thread* thread) NOT_JFR_RETURN();
   public:
     static void send_allocation_outside_tlab(Klass* klass, HeapWord* obj, size_t alloc_size, Thread* thread);
     static void send_allocation_in_new_tlab(Klass* klass, HeapWord* obj, size_t tlab_size, size_t alloc_size, Thread* thread);
     static void send_allocation_requiring_gc_event(size_t size, uint gcId);
-    static void opto_slow_allocation_enter(bool is_array, Thread* thread);
-    static void opto_slow_allocation_leave(bool is_array, Thread* thread);
-    static void send_slow_allocation_event(Klass* klass, oop obj,size_t alloc_size, Thread* thread);
-    static void send_opto_fast_allocation_event(Klass* klass, oop obj, size_t alloc_size, Thread* thread);
+    static void opto_slow_allocation_enter(bool is_array, Thread* thread) NOT_JFR_RETURN();
+    static void opto_slow_allocation_leave(bool is_array, Thread* thread) NOT_JFR_RETURN();
+    static void send_slow_allocation_event(Klass* klass, oop obj,size_t alloc_size, Thread* thread) NOT_JFR_RETURN();
+    static void send_opto_fast_allocation_event(Klass* klass, oop obj, size_t alloc_size, Thread* thread) NOT_JFR_RETURN();
 };
 
 #endif // SHARE_VM_GC_SHARED_ALLOCTRACER_HPP

--- a/src/hotspot/share/gc/shared/allocTracer.inline.hpp
+++ b/src/hotspot/share/gc/shared/allocTracer.inline.hpp
@@ -28,6 +28,7 @@
 #include "gc/shared/allocTracer.hpp"
 #include "jfr/jfrEvents.hpp"
 
+#if INCLUDE_JFR
 typedef uintptr_t TraceAddress;
 
 inline void AllocTracer::opto_slow_allocation_enter(bool is_array, Thread* thread) {
@@ -112,5 +113,6 @@ inline void AllocTracer::send_opto_fast_allocation_event(Klass* klass, oop obj, 
   jlong interval = JfrOptionSet::object_allocations_sampling_interval();
   thread->jfr_thread_local()->incr_alloc_count_until_sample(interval);
 }
+#endif
 
 #endif /* SHARE_VM_GC_INTERFACE_ALLOCTRACER_INLINE_HPP */

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -279,8 +279,12 @@
 
 #if INCLUDE_JFR
 #define JFR_ONLY(code) code
+#define NOT_JFR_RETURN()      /* next token must be ; */
+#define NOT_JFR_RETURN_(code) /* next token must be ; */
 #else
 #define JFR_ONLY(code)
+#define NOT_JFR_RETURN()      {}
+#define NOT_JFR_RETURN_(code) { return code; }
 #endif
 
 #ifndef INCLUDE_JVMCI


### PR DESCRIPTION
Summary: add two macros NOT_JFR_RETURN/NOT_JFR_RETURN_(also exist in
upstream)

Reviewed-by: kuaiwei, kelthuzadx

Test Plan: minimal build

Issue: https://github.com/alibaba/dragonwell11/issues/65