### PR TITLE
[Misc] 8254994: [x86] C1 StubAssembler::call_RT, "call_offset might n…

### DIFF
--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -68,7 +68,7 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   push(thread);
 #endif // _LP64
 
-  int call_offset;
+  int call_offset = -1;
   if (!align_stack) {
     set_last_Java_frame(thread, noreg, rbp, NULL);
   } else {
@@ -132,6 +132,8 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   if (metadata_result->is_valid()) {
     get_vm_result_2(metadata_result, thread);
   }
+
+  assert(call_offset >= 0, "Should be set");
   return call_offset;
 }
 


### PR DESCRIPTION
…ot be initialized"

Summary: Backport of JDK-8254994. (https://github.com/openjdk/jdk/commit/355f44dd11)

Reviewed-by: kuaiwei, kelthuzadx

Test Plan: minimal build

Issue: https://github.com/alibaba/dragonwell11/issues/65