### PR TITLE
Merge ZGC root iteration, SA, etc.

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -973,6 +973,7 @@ class java_lang_ref_Reference: AllStatic {
   static inline oop queue(oop ref);
   static inline void set_queue(oop ref, oop value);
   static bool is_referent_field(oop obj, ptrdiff_t offset);
+  ZGC_ONLY( static inline bool is_final(oop ref); )
   static inline bool is_phantom(oop ref);
 };
 

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -127,6 +127,11 @@ void java_lang_ref_Reference::set_discovered_raw(oop ref, oop value) {
 HeapWord* java_lang_ref_Reference::discovered_addr_raw(oop ref) {
   return ref->obj_field_addr_raw<HeapWord>(discovered_offset);
 }
+#if INCLUDE_ZGC
+bool java_lang_ref_Reference::is_final(oop ref) {
+  return InstanceKlass::cast(ref->klass())->reference_type() == REF_FINAL;
+}
+#endif
 bool java_lang_ref_Reference::is_phantom(oop ref) {
   return InstanceKlass::cast(ref->klass())->reference_type() == REF_PHANTOM;
 }

--- a/src/hotspot/share/gc/shared/accessBarrierSupport.cpp
+++ b/src/hotspot/share/gc/shared/accessBarrierSupport.cpp
@@ -29,7 +29,8 @@
 
 DecoratorSet AccessBarrierSupport::resolve_unknown_oop_ref_strength(DecoratorSet decorators, oop base, ptrdiff_t offset) {
   DecoratorSet ds = decorators & ~ON_UNKNOWN_OOP_REF;
-  if (!java_lang_ref_Reference::is_referent_field(base, offset)) {
+  if (!java_lang_ref_Reference::is_referent_field(base, offset)
+      ZGC_ONLY( || (UseZGC && java_lang_ref_Reference::is_final(base)))) {
     ds |= ON_STRONG_OOP_REF;
   } else if (java_lang_ref_Reference::is_phantom(base)) {
     ds |= ON_PHANTOM_OOP_REF;

--- a/src/hotspot/share/gc/shared/workgroup.hpp
+++ b/src/hotspot/share/gc/shared/workgroup.hpp
@@ -153,7 +153,7 @@ class AbstractWorkGang : public CHeapObj<mtInternal> {
   virtual uint active_workers() const {
     assert(_active_workers <= _total_workers,
            "_active_workers: %u > _total_workers: %u", _active_workers, _total_workers);
-    assert(UseDynamicNumberOfGCThreads || _active_workers == _total_workers,
+    assert(ZGC_ONLY(UseZGC ||) UseDynamicNumberOfGCThreads || _active_workers == _total_workers,
            "Unless dynamic should use total workers");
     return _active_workers;
   }

--- a/src/hotspot/share/gc/z/zAddress.hpp
+++ b/src/hotspot/share/gc/z/zAddress.hpp
@@ -37,6 +37,7 @@ public:
   static bool is_weak_good_or_null(uintptr_t value);
   static bool is_marked(uintptr_t value);
   static bool is_finalizable(uintptr_t value);
+  static bool is_finalizable_good(uintptr_t value);
   static bool is_remapped(uintptr_t value);
 
   static uintptr_t address(uintptr_t value);

--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -74,6 +74,10 @@ inline bool ZAddress::is_finalizable(uintptr_t value) {
   return value & ZAddressMetadataFinalizable;
 }
 
+inline bool ZAddress::is_finalizable_good(uintptr_t value) {
+  return is_finalizable(value) && is_good(value ^ ZAddressMetadataFinalizable);
+}
+
 inline bool ZAddress::is_remapped(uintptr_t value) {
   return value & ZAddressMetadataRemapped;
 }

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -76,9 +76,6 @@ void ZArguments::initialize() {
   }
 #endif
 
-  // To avoid asserts in set_active_workers()
-  FLAG_SET_DEFAULT(UseDynamicNumberOfGCThreads, true);
-
   // CompressedOops/UseCompressedClassPointers not supported
   FLAG_SET_DEFAULT(UseCompressedOops, false);
   FLAG_SET_DEFAULT(UseCompressedClassPointers, false);

--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -33,6 +33,7 @@
 #include "gc/z/zServiceability.hpp"
 #include "gc/z/zStat.hpp"
 #include "logging/log.hpp"
+#include "memory/universe.hpp"
 #include "runtime/vmOperations.hpp"
 #include "runtime/vmThread.hpp"
 
@@ -44,6 +45,7 @@ static const ZStatPhasePause      ZPhasePauseMarkEnd("Pause Mark End");
 static const ZStatPhaseConcurrent ZPhaseConcurrentProcessNonStrongReferences("Concurrent Process Non-Strong References");
 static const ZStatPhaseConcurrent ZPhaseConcurrentResetRelocationSet("Concurrent Reset Relocation Set");
 static const ZStatPhaseConcurrent ZPhaseConcurrentDestroyDetachedPages("Concurrent Destroy Detached Pages");
+static const ZStatPhasePause      ZPhasePauseVerify("Pause Verify");
 static const ZStatPhaseConcurrent ZPhaseConcurrentSelectRelocationSet("Concurrent Select Relocation Set");
 static const ZStatPhaseConcurrent ZPhaseConcurrentPrepareRelocationSet("Concurrent Prepare Relocation Set");
 static const ZStatPhasePause      ZPhasePauseRelocateStart("Pause Relocate Start");
@@ -210,6 +212,19 @@ public:
   }
 };
 
+class ZVerifyClosure : public ZOperationClosure {
+public:
+  virtual const char* name() const {
+    return "ZVerify";
+  }
+
+  virtual bool do_operation() {
+    ZStatTimer timer(ZPhasePauseVerify);
+    Universe::verify();
+    return true;
+  }
+};
+
 class ZRelocateStartClosure : public ZOperationClosure {
 public:
   virtual const char* name() const {
@@ -367,25 +382,31 @@ void ZDriver::run_gc_cycle(GCCause::Cause cause) {
     ZHeap::heap()->destroy_detached_pages();
   }
 
-  // Phase 7: Concurrent Select Relocation Set
+  // Phase 7: Pause Verify
+  if (VerifyBeforeGC || VerifyDuringGC || VerifyAfterGC) {
+    ZVerifyClosure cl;
+    vm_operation(&cl);
+  }
+
+  // Phase 8: Concurrent Select Relocation Set
   {
     ZStatTimer timer(ZPhaseConcurrentSelectRelocationSet);
     ZHeap::heap()->select_relocation_set();
   }
 
-  // Phase 8: Concurrent Prepare Relocation Set
+  // Phase 9: Concurrent Prepare Relocation Set
   {
     ZStatTimer timer(ZPhaseConcurrentPrepareRelocationSet);
     ZHeap::heap()->prepare_relocation_set();
   }
 
-  // Phase 9: Pause Relocate Start
+  // Phase 10: Pause Relocate Start
   {
     ZRelocateStartClosure cl;
     vm_operation(&cl);
   }
 
-  // Phase 10: Concurrent Relocate
+  // Phase 11: Concurrent Relocate
   {
     ZStatTimer timer(ZPhaseConcurrentRelocated);
     ZHeap::heap()->relocate();

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -304,6 +304,17 @@ void ZHeap::mark_flush_and_free(Thread* thread) {
   _mark.flush_and_free(thread);
 }
 
+class ZFixupPartialLoadsClosure : public ZRootsIteratorClosure {
+public:
+  virtual void do_oop(oop* p) {
+    ZBarrier::mark_barrier_on_root_oop_field(p);
+  }
+
+  virtual void do_oop(narrowOop* p) {
+    ShouldNotReachHere();
+  }
+};
+
 class ZFixupPartialLoadsTask : public ZTask {
 private:
   ZThreadRootsIterator _thread_roots;
@@ -314,7 +325,7 @@ public:
       _thread_roots() {}
 
   virtual void work() {
-    ZMarkRootOopClosure cl;
+    ZFixupPartialLoadsClosure cl;
     _thread_roots.oops_do(&cl);
   }
 };

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -366,11 +366,6 @@ bool ZHeap::mark_end() {
   // Process weak roots
   _weak_roots_processor.process_weak_roots();
 
-  // Verification
-  if (VerifyBeforeGC || VerifyDuringGC || VerifyAfterGC) {
-    Universe::verify();
-  }
-
   return true;
 }
 
@@ -573,7 +568,7 @@ public:
       _weak_roots() {}
 
   virtual void work() {
-    ZVerifyRootOopClosure cl;
+    ZVerifyOopClosure cl;
     _strong_roots.oops_do(&cl);
     _weak_roots.oops_do(&cl);
   }

--- a/src/hotspot/share/gc/z/zHeapIterator.cpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public:
   }
 };
 
-class ZHeapIteratorRootOopClosure : public OopClosure {
+class ZHeapIteratorRootOopClosure : public ZRootsIteratorClosure {
 private:
   ZHeapIterator* const _iter;
   ObjectClosure* const _cl;

--- a/src/hotspot/share/gc/z/zHeapIterator.hpp
+++ b/src/hotspot/share/gc/z/zHeapIterator.hpp
@@ -33,7 +33,7 @@ class ZHeapIteratorBitMap;
 
 class ZHeapIterator : public StackObj {
   friend class ZHeapIteratorRootOopClosure;
-  friend class ZHeapIteratorPushOopClosure;
+  friend class ZHeapIteratorOopClosure;
 
 private:
   typedef ZAddressRangeMap<ZHeapIteratorBitMap*, ZPageSizeMinShift>         ZVisitMap;
@@ -44,14 +44,8 @@ private:
   ZVisitMap   _visit_map;
   const bool  _visit_referents;
 
-  size_t object_index_max() const;
-  size_t object_index(oop obj) const;
   ZHeapIteratorBitMap* object_map(oop obj);
-
   void push(oop obj);
-  void drain(ObjectClosure* cl);
-
-  bool visit_referents() const;
 
 public:
   ZHeapIterator(bool visit_referents);

--- a/src/hotspot/share/gc/z/zLock.hpp
+++ b/src/hotspot/share/gc/z/zLock.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,18 +33,35 @@ private:
 
 public:
   ZLock();
+  ~ZLock();
 
   void lock();
   bool try_lock();
   void unlock();
 };
 
-class ZLocker : public StackObj {
+class ZReentrantLock {
 private:
-  ZLock* const _lock;
+  ZLock            _lock;
+  Thread* volatile _owner;
+  uint64_t         _count;
 
 public:
-  ZLocker(ZLock* lock);
+  ZReentrantLock();
+
+  void lock();
+  void unlock();
+
+  bool is_owned() const;
+};
+
+template <typename T>
+class ZLocker : public StackObj {
+private:
+  T* const _lock;
+
+public:
+  ZLocker(T* lock);
   ~ZLocker();
 };
 

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -82,7 +82,7 @@ uintptr_t ZMarkStackSpace::alloc_space(size_t size) {
 }
 
 uintptr_t ZMarkStackSpace::expand_and_alloc_space(size_t size) {
-  ZLocker locker(&_expand_lock);
+  ZLocker<ZLock> locker(&_expand_lock);
 
   // Retry allocation before expanding
   uintptr_t addr = alloc_space(size);

--- a/src/hotspot/share/gc/z/zOop.hpp
+++ b/src/hotspot/share/gc/z/zOop.hpp
@@ -33,7 +33,7 @@ public:
   static uintptr_t to_address(oop o);
 
   static bool is_good(oop o);
-  static bool is_good_or_null(oop o);
+  static bool is_finalizable_good(oop o);
 
   static oop good(oop);
 };

--- a/src/hotspot/share/gc/z/zOop.inline.hpp
+++ b/src/hotspot/share/gc/z/zOop.inline.hpp
@@ -40,8 +40,8 @@ inline bool ZOop::is_good(oop o) {
   return ZAddress::is_good(to_address(o));
 }
 
-inline bool ZOop::is_good_or_null(oop o) {
-  return ZAddress::is_good_or_null(to_address(o));
+inline bool ZOop::is_finalizable_good(oop o) {
+  return ZAddress::is_finalizable_good(to_address(o));
 }
 
 inline oop ZOop::good(oop o) {

--- a/src/hotspot/share/gc/z/zOopClosures.hpp
+++ b/src/hotspot/share/gc/z/zOopClosures.hpp
@@ -25,6 +25,7 @@
 #define SHARE_GC_Z_ZOOPCLOSURES_HPP
 
 #include "memory/iterator.hpp"
+#include "gc/z/zRootsIterator.hpp"
 
 class ZLoadBarrierOopClosure : public BasicOopIterateClosure {
 public:
@@ -36,18 +37,6 @@ public:
     return false;
   }
 #endif
-};
-
-class ZMarkRootOopClosure : public OopClosure {
-public:
-  virtual void do_oop(oop* p);
-  virtual void do_oop(narrowOop* p);
-};
-
-class ZRelocateRootOopClosure : public OopClosure {
-public:
-  virtual void do_oop(oop* p);
-  virtual void do_oop(narrowOop* p);
 };
 
 template <bool finalizable>
@@ -70,13 +59,13 @@ public:
   virtual bool do_object_b(oop o);
 };
 
-class ZPhantomKeepAliveOopClosure : public OopClosure {
+class ZPhantomKeepAliveOopClosure : public ZRootsIteratorClosure {
 public:
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);
 };
 
-class ZPhantomCleanOopClosure : public OopClosure {
+class ZPhantomCleanOopClosure : public ZRootsIteratorClosure {
 public:
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);
@@ -97,7 +86,7 @@ public:
 #endif
 };
 
-class ZVerifyRootOopClosure : public OopClosure {
+class ZVerifyRootOopClosure : public ZRootsIteratorClosure {
 public:
   ZVerifyRootOopClosure();
 

--- a/src/hotspot/share/gc/z/zOopClosures.hpp
+++ b/src/hotspot/share/gc/z/zOopClosures.hpp
@@ -71,27 +71,21 @@ public:
   virtual void do_oop(narrowOop* p);
 };
 
-class ZVerifyHeapOopClosure : public BasicOopIterateClosure {
+class ZVerifyOopClosure : public ZRootsIteratorClosure, public BasicOopIterateClosure {
 public:
-  virtual ReferenceIterationMode reference_iteration_mode();
-
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);
 
+  virtual ReferenceIterationMode reference_iteration_mode() {
+    return DO_FIELDS;
+  }
+
 #ifdef ASSERT
-  // Verification handled by the closure itself.
+  // Verification handled by the closure itself
   virtual bool should_verify_oops() {
     return false;
   }
 #endif
-};
-
-class ZVerifyRootOopClosure : public ZRootsIteratorClosure {
-public:
-  ZVerifyRootOopClosure();
-
-  virtual void do_oop(oop* p);
-  virtual void do_oop(narrowOop* p);
 };
 
 class ZVerifyObjectClosure : public ObjectClosure {

--- a/src/hotspot/share/gc/z/zOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/z/zOopClosures.inline.hpp
@@ -40,22 +40,6 @@ inline void ZLoadBarrierOopClosure::do_oop(narrowOop* p) {
   ShouldNotReachHere();
 }
 
-inline void ZMarkRootOopClosure::do_oop(oop* p) {
-  ZBarrier::mark_barrier_on_root_oop_field(p);
-}
-
-inline void ZMarkRootOopClosure::do_oop(narrowOop* p) {
-  ShouldNotReachHere();
-}
-
-inline void ZRelocateRootOopClosure::do_oop(oop* p) {
-  ZBarrier::relocate_barrier_on_root_oop_field(p);
-}
-
-inline void ZRelocateRootOopClosure::do_oop(narrowOop* p) {
-  ShouldNotReachHere();
-}
-
 template <bool finalizable>
 inline ZMarkBarrierOopClosure<finalizable>::ZMarkBarrierOopClosure() :
     BasicOopIterateClosure(finalizable ? NULL : ZHeap::heap()->reference_discoverer()) {}

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -285,11 +285,6 @@ inline uintptr_t ZPage::alloc_object(size_t size) {
 
   _top = new_top;
 
-  // Fill alignment padding if needed
-  if (aligned_size != size) {
-    ZUtils::insert_filler_object(addr + size, aligned_size - size);
-  }
-
   return ZAddress::good(addr);
 }
 
@@ -308,11 +303,6 @@ inline uintptr_t ZPage::alloc_object_atomic(size_t size) {
 
     const uintptr_t prev_top = Atomic::cmpxchg(new_top, &_top, addr);
     if (prev_top == addr) {
-      // Fill alignment padding if needed
-      if (aligned_size != size) {
-        ZUtils::insert_filler_object(addr + size, aligned_size - size);
-      }
-
       // Success
       return ZAddress::good(addr);
     }

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -260,7 +260,7 @@ void ZPageAllocator::destroy_page(ZPage* page) {
 
   // Free virtual memory
   {
-    ZLocker locker(&_lock);
+    ZLocker<ZLock> locker(&_lock);
     _virtual.free(page->virtual_memory());
   }
 
@@ -268,7 +268,7 @@ void ZPageAllocator::destroy_page(ZPage* page) {
 }
 
 void ZPageAllocator::flush_detached_pages(ZList<ZPage>* list) {
-  ZLocker locker(&_lock);
+  ZLocker<ZLock> locker(&_lock);
   list->transfer(&_detached);
 }
 
@@ -376,7 +376,7 @@ ZPage* ZPageAllocator::alloc_page_blocking(uint8_t type, size_t size, ZAllocatio
       // thread have returned from sem_wait(). To avoid this race we are
       // forcing the waiting thread to acquire/release the lock held by the
       // posting thread. https://sourceware.org/bugzilla/show_bug.cgi?id=12674
-      ZLocker locker(&_lock);
+      ZLocker<ZLock> locker(&_lock);
     }
   }
 
@@ -384,7 +384,7 @@ ZPage* ZPageAllocator::alloc_page_blocking(uint8_t type, size_t size, ZAllocatio
 }
 
 ZPage* ZPageAllocator::alloc_page_nonblocking(uint8_t type, size_t size, ZAllocationFlags flags) {
-  ZLocker locker(&_lock);
+  ZLocker<ZLock> locker(&_lock);
   return alloc_page_common(type, size, flags);
 }
 
@@ -477,7 +477,7 @@ void ZPageAllocator::flip_pre_mapped() {
 }
 
 void ZPageAllocator::free_page(ZPage* page, bool reclaimed) {
-  ZLocker locker(&_lock);
+  ZLocker<ZLock> locker(&_lock);
 
   // Update used statistics
   decrease_used(page->size(), reclaimed);
@@ -495,7 +495,7 @@ bool ZPageAllocator::is_alloc_stalled() const {
 }
 
 void ZPageAllocator::check_out_of_memory() {
-  ZLocker locker(&_lock);
+  ZLocker<ZLock> locker(&_lock);
 
   // Fail allocation requests that were enqueued before the
   // last GC cycle started, otherwise start a new GC cycle.

--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -75,25 +75,25 @@ static const ZStatSubPhase ZSubPhaseConcurrentWeakRootsVMWeakHandles("Concurrent
 static const ZStatSubPhase ZSubPhaseConcurrentWeakRootsJNIWeakHandles("Concurrent Weak Roots JNIWeakHandles");
 static const ZStatSubPhase ZSubPhaseConcurrentWeakRootsStringTable("Concurrent Weak Roots StringTable");
 
-template <typename T, void (T::*F)(OopClosure*)>
+template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
 ZSerialOopsDo<T, F>::ZSerialOopsDo(T* iter) :
     _iter(iter),
     _claimed(false) {}
 
-template <typename T, void (T::*F)(OopClosure*)>
-void ZSerialOopsDo<T, F>::oops_do(OopClosure* cl) {
+template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
+void ZSerialOopsDo<T, F>::oops_do(ZRootsIteratorClosure* cl) {
   if (!_claimed && Atomic::cmpxchg(true, &_claimed, false) == false) {
     (_iter->*F)(cl);
   }
 }
 
-template <typename T, void (T::*F)(OopClosure*)>
+template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
 ZParallelOopsDo<T, F>::ZParallelOopsDo(T* iter) :
     _iter(iter),
     _completed(false) {}
 
-template <typename T, void (T::*F)(OopClosure*)>
-void ZParallelOopsDo<T, F>::oops_do(OopClosure* cl) {
+template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
+void ZParallelOopsDo<T, F>::oops_do(ZRootsIteratorClosure* cl) {
   if (!_completed) {
     (_iter->*F)(cl);
     if (!_completed) {
@@ -102,25 +102,25 @@ void ZParallelOopsDo<T, F>::oops_do(OopClosure* cl) {
   }
 }
 
-template <typename T, void (T::*F)(BoolObjectClosure*, OopClosure*)>
+template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
 ZSerialWeakOopsDo<T, F>::ZSerialWeakOopsDo(T* iter) :
     _iter(iter),
     _claimed(false) {}
 
-template <typename T, void (T::*F)(BoolObjectClosure*, OopClosure*)>
-void ZSerialWeakOopsDo<T, F>::weak_oops_do(BoolObjectClosure* is_alive, OopClosure* cl) {
+template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
+void ZSerialWeakOopsDo<T, F>::weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
   if (!_claimed && Atomic::cmpxchg(true, &_claimed, false) == false) {
     (_iter->*F)(is_alive, cl);
   }
 }
 
-template <typename T, void (T::*F)(BoolObjectClosure*, OopClosure*)>
+template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
 ZParallelWeakOopsDo<T, F>::ZParallelWeakOopsDo(T* iter) :
     _iter(iter),
     _completed(false) {}
 
-template <typename T, void (T::*F)(BoolObjectClosure*, OopClosure*)>
-void ZParallelWeakOopsDo<T, F>::weak_oops_do(BoolObjectClosure* is_alive, OopClosure* cl) {
+template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
+void ZParallelWeakOopsDo<T, F>::weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
   if (!_completed) {
     (_iter->*F)(is_alive, cl);
     if (!_completed) {
@@ -160,80 +160,60 @@ ZRootsIterator::~ZRootsIterator() {
   Threads::assert_all_threads_claimed();
 }
 
-void ZRootsIterator::do_universe(OopClosure* cl) {
+void ZRootsIterator::do_universe(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsUniverse);
   Universe::oops_do(cl);
 }
 
-void ZRootsIterator::do_jni_handles(OopClosure* cl) {
+void ZRootsIterator::do_jni_handles(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsJNIHandles);
   _jni_handles_iter.oops_do(cl);
 }
 
-void ZRootsIterator::do_object_synchronizer(OopClosure* cl) {
+void ZRootsIterator::do_object_synchronizer(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsObjectSynchronizer);
   ObjectSynchronizer::oops_do(cl);
 }
 
-void ZRootsIterator::do_management(OopClosure* cl) {
+void ZRootsIterator::do_management(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsManagement);
   Management::oops_do(cl);
 }
 
-void ZRootsIterator::do_jvmti_export(OopClosure* cl) {
+void ZRootsIterator::do_jvmti_export(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsJVMTIExport);
   JvmtiExport::oops_do(cl);
 }
 
-void ZRootsIterator::do_jvmti_weak_export(OopClosure* cl) {
+void ZRootsIterator::do_jvmti_weak_export(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsJVMTIWeakExport);
   AlwaysTrueClosure always_alive;
   JvmtiExport::weak_oops_do(&always_alive, cl);
 }
 
-void ZRootsIterator::do_system_dictionary(OopClosure* cl) {
+void ZRootsIterator::do_system_dictionary(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsSystemDictionary);
   SystemDictionary::oops_do(cl);
 }
 
-void ZRootsIterator::do_class_loader_data_graph(OopClosure* cl) {
+void ZRootsIterator::do_class_loader_data_graph(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsClassLoaderDataGraph);
   CLDToOopClosure cld_cl(cl);
   ClassLoaderDataGraph::cld_do(&cld_cl);
 }
 
-class ZRootsIteratorThreadClosure : public ThreadClosure {
-private:
-  OopClosure* const _cl;
-
-public:
-  ZRootsIteratorThreadClosure(OopClosure* cl) :
-      _cl(cl) {}
-
-  virtual void do_thread(Thread* thread) {
-    if (thread->is_Java_thread()) {
-      // Update thread local address bad mask
-      ZThreadLocalData::set_address_bad_mask(thread, ZAddressBadMask);
-    }
-
-    // Process thread oops
-    thread->oops_do(_cl, NULL);
-  }
-};
-
-void ZRootsIterator::do_threads(OopClosure* cl) {
+void ZRootsIterator::do_threads(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsThreads);
   ResourceMark rm;
-  ZRootsIteratorThreadClosure thread_cl(cl);
-  Threads::possibly_parallel_threads_do(true, &thread_cl);
+  Threads::possibly_parallel_threads_do(true, cl);
 }
 
-void ZRootsIterator::do_code_cache(OopClosure* cl) {
+void ZRootsIterator::do_code_cache(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsCodeCache);
   ZNMethodTable::oops_do(cl);
 }
 
-void ZRootsIterator::oops_do(OopClosure* cl, bool visit_jvmti_weak_export) {
+void ZRootsIterator::oops_do(ZRootsIteratorClosure* cl, bool visit_jvmti_weak_export) {
   ZStatTimer timer(ZSubPhasePauseRoots);
   _universe.oops_do(cl);
   _object_synchronizer.oops_do(cl);
@@ -262,25 +242,25 @@ ZWeakRootsIterator::~ZWeakRootsIterator() {
   ZStatTimer timer(ZSubPhasePauseWeakRootsTeardown);
 }
 
-void ZWeakRootsIterator::do_jvmti_weak_export(BoolObjectClosure* is_alive, OopClosure* cl) {
+void ZWeakRootsIterator::do_jvmti_weak_export(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseWeakRootsJVMTIWeakExport);
   JvmtiExport::weak_oops_do(is_alive, cl);
 }
 
-void ZWeakRootsIterator::do_jfr_weak(BoolObjectClosure* is_alive, OopClosure* cl) {
+void ZWeakRootsIterator::do_jfr_weak(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
 #if INCLUDE_JFR
   ZStatTimer timer(ZSubPhasePauseWeakRootsJFRWeak);
   Jfr::weak_oops_do(is_alive, cl);
 #endif
 }
 
-void ZWeakRootsIterator::do_symbol_table(BoolObjectClosure* is_alive, OopClosure* cl) {
+void ZWeakRootsIterator::do_symbol_table(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseWeakRootsSymbolTable);
   int dummy;
   SymbolTable::possibly_parallel_unlink(&dummy, &dummy);
 }
 
-void ZWeakRootsIterator::weak_oops_do(BoolObjectClosure* is_alive, OopClosure* cl) {
+void ZWeakRootsIterator::weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseWeakRoots);
   if (ZSymbolTableUnloading) {
     _symbol_table.weak_oops_do(is_alive, cl);
@@ -289,7 +269,7 @@ void ZWeakRootsIterator::weak_oops_do(BoolObjectClosure* is_alive, OopClosure* c
   _jfr_weak.weak_oops_do(is_alive, cl);
 }
 
-void ZWeakRootsIterator::oops_do(OopClosure* cl) {
+void ZWeakRootsIterator::oops_do(ZRootsIteratorClosure* cl) {
   AlwaysTrueClosure always_alive;
   weak_oops_do(&always_alive, cl);
 }
@@ -308,27 +288,27 @@ ZConcurrentWeakRootsIterator::~ZConcurrentWeakRootsIterator() {
   StringTable::finish_dead_counter();
 }
 
-void ZConcurrentWeakRootsIterator::do_vm_weak_handles(OopClosure* cl) {
+void ZConcurrentWeakRootsIterator::do_vm_weak_handles(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhaseConcurrentWeakRootsVMWeakHandles);
   _vm_weak_handles_iter.oops_do(cl);
 }
 
-void ZConcurrentWeakRootsIterator::do_jni_weak_handles(OopClosure* cl) {
+void ZConcurrentWeakRootsIterator::do_jni_weak_handles(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhaseConcurrentWeakRootsJNIWeakHandles);
   _jni_weak_handles_iter.oops_do(cl);
 }
 
-class ZStringTableDeadCounterOopClosure : public OopClosure  {
+class ZStringTableDeadCounterClosure : public ZRootsIteratorClosure  {
 private:
-  OopClosure* const _cl;
-  size_t            _ndead;
+  ZRootsIteratorClosure* const _cl;
+  size_t                       _ndead;
 
 public:
-  ZStringTableDeadCounterOopClosure(OopClosure* cl) :
+  ZStringTableDeadCounterClosure(ZRootsIteratorClosure* cl) :
       _cl(cl),
       _ndead(0) {}
 
-  ~ZStringTableDeadCounterOopClosure() {
+  ~ZStringTableDeadCounterClosure() {
     StringTable::inc_dead_counter(_ndead);
   }
 
@@ -344,13 +324,13 @@ public:
   }
 };
 
-void ZConcurrentWeakRootsIterator::do_string_table(OopClosure* cl) {
+void ZConcurrentWeakRootsIterator::do_string_table(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhaseConcurrentWeakRootsStringTable);
-  ZStringTableDeadCounterOopClosure counter_cl(cl);
+  ZStringTableDeadCounterClosure counter_cl(cl);
   _string_table_iter.oops_do(&counter_cl);
 }
 
-void ZConcurrentWeakRootsIterator::oops_do(OopClosure* cl) {
+void ZConcurrentWeakRootsIterator::oops_do(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhaseConcurrentWeakRoots);
   _vm_weak_handles.oops_do(cl);
   _jni_weak_handles.oops_do(cl);
@@ -369,13 +349,13 @@ ZThreadRootsIterator::~ZThreadRootsIterator() {
   Threads::assert_all_threads_claimed();
 }
 
-void ZThreadRootsIterator::do_threads(OopClosure* cl) {
+void ZThreadRootsIterator::do_threads(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsThreads);
   ResourceMark rm;
   Threads::possibly_parallel_oops_do(true, cl, NULL);
 }
 
-void ZThreadRootsIterator::oops_do(OopClosure* cl) {
+void ZThreadRootsIterator::oops_do(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRoots);
   _threads.oops_do(cl);
 }

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -27,12 +27,20 @@
 #include "gc/shared/oopStorageParState.hpp"
 #include "memory/allocation.hpp"
 #include "memory/iterator.hpp"
+#include "runtime/thread.hpp"
 #include "utilities/globalDefinitions.hpp"
+
+class ZRootsIteratorClosure : public OopClosure, public ThreadClosure {
+public:
+  virtual void do_thread(Thread* thread) {
+    thread->oops_do(this, NULL);
+  }
+};
 
 typedef OopStorage::ParState<false /* concurrent */, false /* is_const */> ZOopStorageIterator;
 typedef OopStorage::ParState<true /* concurrent */, false /* is_const */>  ZConcurrentOopStorageIterator;
 
-template <typename T, void (T::*F)(OopClosure*)>
+template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
 class ZSerialOopsDo {
 private:
   T* const      _iter;
@@ -40,10 +48,10 @@ private:
 
 public:
   ZSerialOopsDo(T* iter);
-  void oops_do(OopClosure* cl);
+  void oops_do(ZRootsIteratorClosure* cl);
 };
 
-template <typename T, void (T::*F)(OopClosure*)>
+template <typename T, void (T::*F)(ZRootsIteratorClosure*)>
 class ZParallelOopsDo {
 private:
   T* const      _iter;
@@ -51,10 +59,10 @@ private:
 
 public:
   ZParallelOopsDo(T* iter);
-  void oops_do(OopClosure* cl);
+  void oops_do(ZRootsIteratorClosure* cl);
 };
 
-template <typename T, void (T::*F)(BoolObjectClosure*, OopClosure*)>
+template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
 class ZSerialWeakOopsDo {
 private:
   T* const      _iter;
@@ -62,10 +70,10 @@ private:
 
 public:
   ZSerialWeakOopsDo(T* iter);
-  void weak_oops_do(BoolObjectClosure* is_alive, OopClosure* cl);
+  void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
 };
 
-template <typename T, void (T::*F)(BoolObjectClosure*, OopClosure*)>
+template <typename T, void (T::*F)(BoolObjectClosure*, ZRootsIteratorClosure*)>
 class ZParallelWeakOopsDo {
 private:
   T* const      _iter;
@@ -73,23 +81,23 @@ private:
 
 public:
   ZParallelWeakOopsDo(T* iter);
-  void weak_oops_do(BoolObjectClosure* is_alive, OopClosure* cl);
+  void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
 };
 
 class ZRootsIterator {
 private:
   ZOopStorageIterator _jni_handles_iter;
 
-  void do_universe(OopClosure* cl);
-  void do_jni_handles(OopClosure* cl);
-  void do_object_synchronizer(OopClosure* cl);
-  void do_management(OopClosure* cl);
-  void do_jvmti_export(OopClosure* cl);
-  void do_jvmti_weak_export(OopClosure* cl);
-  void do_system_dictionary(OopClosure* cl);
-  void do_class_loader_data_graph(OopClosure* cl);
-  void do_threads(OopClosure* cl);
-  void do_code_cache(OopClosure* cl);
+  void do_universe(ZRootsIteratorClosure* cl);
+  void do_jni_handles(ZRootsIteratorClosure* cl);
+  void do_object_synchronizer(ZRootsIteratorClosure* cl);
+  void do_management(ZRootsIteratorClosure* cl);
+  void do_jvmti_export(ZRootsIteratorClosure* cl);
+  void do_jvmti_weak_export(ZRootsIteratorClosure* cl);
+  void do_system_dictionary(ZRootsIteratorClosure* cl);
+  void do_class_loader_data_graph(ZRootsIteratorClosure* cl);
+  void do_threads(ZRootsIteratorClosure* cl);
+  void do_code_cache(ZRootsIteratorClosure* cl);
 
   ZSerialOopsDo<ZRootsIterator, &ZRootsIterator::do_universe>                  _universe;
   ZSerialOopsDo<ZRootsIterator, &ZRootsIterator::do_object_synchronizer>       _object_synchronizer;
@@ -106,14 +114,14 @@ public:
   ZRootsIterator();
   ~ZRootsIterator();
 
-  void oops_do(OopClosure* cl, bool visit_jvmti_weak_export = false);
+  void oops_do(ZRootsIteratorClosure* cl, bool visit_jvmti_weak_export = false);
 };
 
 class ZWeakRootsIterator {
 private:
-  void do_jvmti_weak_export(BoolObjectClosure* is_alive, OopClosure* cl);
-  void do_jfr_weak(BoolObjectClosure* is_alive, OopClosure* cl);
-  void do_symbol_table(BoolObjectClosure* is_alive, OopClosure* cl);
+  void do_jvmti_weak_export(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
+  void do_jfr_weak(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
+  void do_symbol_table(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
 
   ZSerialWeakOopsDo<ZWeakRootsIterator, &ZWeakRootsIterator::do_jvmti_weak_export>  _jvmti_weak_export;
   ZSerialWeakOopsDo<ZWeakRootsIterator, &ZWeakRootsIterator::do_jfr_weak>           _jfr_weak;
@@ -123,8 +131,8 @@ public:
   ZWeakRootsIterator();
   ~ZWeakRootsIterator();
 
-  void weak_oops_do(BoolObjectClosure* is_alive, OopClosure* cl);
-  void oops_do(OopClosure* cl);
+  void weak_oops_do(BoolObjectClosure* is_alive, ZRootsIteratorClosure* cl);
+  void oops_do(ZRootsIteratorClosure* cl);
 };
 
 class ZConcurrentWeakRootsIterator {
@@ -133,9 +141,9 @@ private:
   ZConcurrentOopStorageIterator _jni_weak_handles_iter;
   ZConcurrentOopStorageIterator _string_table_iter;
 
-  void do_vm_weak_handles(OopClosure* cl);
-  void do_jni_weak_handles(OopClosure* cl);
-  void do_string_table(OopClosure* cl);
+  void do_vm_weak_handles(ZRootsIteratorClosure* cl);
+  void do_jni_weak_handles(ZRootsIteratorClosure* cl);
+  void do_string_table(ZRootsIteratorClosure* cl);
 
   ZParallelOopsDo<ZConcurrentWeakRootsIterator, &ZConcurrentWeakRootsIterator::do_vm_weak_handles>  _vm_weak_handles;
   ZParallelOopsDo<ZConcurrentWeakRootsIterator, &ZConcurrentWeakRootsIterator::do_jni_weak_handles> _jni_weak_handles;
@@ -145,12 +153,12 @@ public:
   ZConcurrentWeakRootsIterator();
   ~ZConcurrentWeakRootsIterator();
 
-  void oops_do(OopClosure* cl);
+  void oops_do(ZRootsIteratorClosure* cl);
 };
 
 class ZThreadRootsIterator {
 private:
-  void do_threads(OopClosure* cl);
+  void do_threads(ZRootsIteratorClosure* cl);
 
   ZParallelOopsDo<ZThreadRootsIterator, &ZThreadRootsIterator::do_threads> _threads;
 
@@ -158,7 +166,7 @@ public:
   ZThreadRootsIterator();
   ~ZThreadRootsIterator();
 
-  void oops_do(OopClosure* cl);
+  void oops_do(ZRootsIteratorClosure* cl);
 };
 
 #endif // SHARE_GC_Z_ZROOTSITERATOR_HPP

--- a/src/hotspot/share/gc/z/zUtils.cpp
+++ b/src/hotspot/share/gc/z/zUtils.cpp
@@ -22,8 +22,6 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/shared/collectedHeap.hpp"
-#include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zUtils.inline.hpp"
 #include "utilities/debug.hpp"
 
@@ -39,11 +37,4 @@ uintptr_t ZUtils::alloc_aligned(size_t alignment, size_t size) {
   memset(res, 0, size);
 
   return (uintptr_t)res;
-}
-
-void ZUtils::insert_filler_object(uintptr_t addr, size_t size) {
-  const size_t fill_size_in_words = bytes_to_words(size);
-  if (fill_size_in_words >= CollectedHeap::min_fill_size()) {
-    CollectedHeap::fill_with_objects((HeapWord*)ZAddress::good(addr), fill_size_in_words);
-  }
 }

--- a/src/hotspot/share/gc/z/zUtils.hpp
+++ b/src/hotspot/share/gc/z/zUtils.hpp
@@ -42,9 +42,6 @@ public:
   // Object
   static size_t object_size(uintptr_t addr);
   static void object_copy(uintptr_t from, uintptr_t to, size_t size);
-
-  // Filler
-  static void insert_filler_object(uintptr_t addr, size_t size);
 };
 
 #endif // SHARE_GC_Z_ZUTILS_HPP

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2577,7 +2577,7 @@ class SimpleRootsClosure : public OopClosure {
       return;
     }
 
-    oop o = *obj_p;
+    oop o = ZGC_ONLY(UseZGC ? NativeAccess<AS_NO_KEEPALIVE>::oop_load(obj_p) :) (*obj_p);
     // ignore null
     if (o == NULL) {
       return;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ObjectHeap.java
@@ -38,6 +38,7 @@ import sun.jvm.hotspot.gc.epsilon.*;
 import sun.jvm.hotspot.gc.g1.*;
 import sun.jvm.hotspot.gc.shenandoah.*;
 import sun.jvm.hotspot.gc.parallel.*;
+import sun.jvm.hotspot.gc.z.*;
 import sun.jvm.hotspot.memory.*;
 import sun.jvm.hotspot.runtime.*;
 import sun.jvm.hotspot.types.*;
@@ -444,6 +445,10 @@ public class ObjectHeap {
        // Operation (currently) not supported with Shenandoah GC. Print
        // a warning and leave the list of live regions empty.
        System.err.println("Warning: Operation not supported with Shenandoah GC");
+    } else if (heap instanceof ZCollectedHeap) {
+       // Operation (currently) not supported with ZGC. Print
+       // a warning and leave the list of live regions empty.
+       System.err.println("Warning: Operation not supported with ZGC");
     } else if (heap instanceof EpsilonHeap) {
        EpsilonHeap eh = (EpsilonHeap) heap;
        liveRegions.add(eh.space().top());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ProgressiveHeapVisitor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/ProgressiveHeapVisitor.java
@@ -50,6 +50,7 @@ public class ProgressiveHeapVisitor implements HeapVisitor {
     this.usedSize = usedSize;
     visitedSize = 0;
     userHeapVisitor.prologue(usedSize);
+    thunk.heapIterationFractionUpdate(0.0);
   }
 
   public boolean doObj(Oop obj) {

--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java
@@ -48,6 +48,7 @@ import jdk.test.lib.Asserts;
  * @bug 8171084
  * @requires vm.hasSAandCanAttach & (vm.bits == "64" & os.maxMemory > 8g)
  * @requires vm.gc != "Shenandoah"
+ * @requires vm.gc != "Z"
  * @modules java.base/jdk.internal.misc
  *          jdk.hotspot.agent/sun.jvm.hotspot
  *          jdk.hotspot.agent/sun.jvm.hotspot.utilities

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJhisto.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJhisto.java
@@ -35,6 +35,7 @@ import jdk.test.lib.Utils;
  * @summary Test clhsdb jhisto command
  * @requires vm.hasSA
  * @requires vm.gc != "Shenandoah"
+ * @requires vm.gc != "Z"
  * @library /test/lib
  * @run main/othervm ClhsdbJhisto
  */

--- a/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
@@ -50,6 +50,7 @@ import jdk.test.lib.hprof.model.Snapshot;
  * @test
  * @library /test/lib
  * @requires vm.hasSAandCanAttach & os.family != "mac"
+ * @requires vm.gc != "Z"
  * @modules java.base/jdk.internal.misc
  *          jdk.hotspot.agent/sun.jvm.hotspot
  *          jdk.hotspot.agent/sun.jvm.hotspot.utilities


### PR DESCRIPTION
[GC] 8210881: ZGC: Introduce ZRootsIteratorClosure @mmyxym @linade 
[GC] 8210884: ZGC: Remove insertion of filler objects @leveretconey @linade @leveretconey 
[GC] 8209163: SA: Show Object Histogram asserts with ZGC @linade @leveretconey 
[GC] 8210045: Allow using a subset of worker threads even when UseDynamicNumberOfGCThreads is not set @linade @leveretconey 
[GC] 8212181: ZGC: Fix incorrect root iteration in ZHeapIterator @linade @leveretconey 
[GC] 8212184: Incorrect oop ref strength used for referents in FinalReference @linade @leveretconey 
[GC] 8212921: ZGC: Move verification to after resurrection unblocked @mmyxym @leveretconey 
[GC] 8214068: ZGC crashes with vmTestbase/nsk/jdi/ReferenceType/instances/instances004/TestDescription.java @mmyxym @leveretconey 
[GC] 8212748: ZGC: Add reentrant locking functionality @mmyxym @leveretconey 
[GC] 8214484: ZGC: Exclude SA tests ClhsdbJhisto and TestHeapDumpFor* @linade @leveretconey 