### PR TITLE
Merge [GC] Minor optimization of ZBarrierSetAssembler, ZReferenceProcess, ZForwardingTableEntry, etc. 

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -143,6 +143,12 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   ifeq ($(call check-jvm-feature, shenandoahgc), true)
     AD_SRC_FILES += $(call uniq, $(wildcard $(foreach d, $(AD_SRC_ROOTS), \
         $d/cpu/$(HOTSPOT_TARGET_CPU_ARCH)/gc/shenandoah/shenandoah_$(HOTSPOT_TARGET_CPU).ad \
+      )))
+  endif
+
+  ifeq ($(call check-jvm-feature, zgc), true)
+    AD_SRC_FILES += $(call uniq, $(wildcard $(foreach d, $(AD_SRC_ROOTS), \
+        $d/cpu/$(HOTSPOT_TARGET_CPU_ARCH)/gc/z/z_$(HOTSPOT_TARGET_CPU).ad \
       )))
   endif
 

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -37,14 +37,18 @@
 #include "gc/z/c1/zBarrierSetC1.hpp"
 #endif // COMPILER1
 
-#undef __
-#define __ masm->
+ZBarrierSetAssembler::ZBarrierSetAssembler() :
+    _load_barrier_slow_stub(),
+    _load_barrier_weak_slow_stub() {}
 
 #ifdef PRODUCT
 #define BLOCK_COMMENT(str) /* nothing */
 #else
 #define BLOCK_COMMENT(str) __ block_comment(str)
 #endif
+
+#undef __
+#define __ masm->
 
 static void call_vm(MacroAssembler* masm,
                     address entry_point,
@@ -460,4 +464,12 @@ static void barrier_stubs_init_inner(const char* label, const DecoratorSet decor
 void ZBarrierSetAssembler::barrier_stubs_init() {
   barrier_stubs_init_inner("zgc_load_barrier_stubs", ON_STRONG_OOP_REF, _load_barrier_slow_stub);
   barrier_stubs_init_inner("zgc_load_barrier_weak_stubs", ON_WEAK_OOP_REF, _load_barrier_weak_slow_stub);
+}
+
+address ZBarrierSetAssembler::load_barrier_slow_stub(Register reg) {
+  return _load_barrier_slow_stub[reg->encoding()];
+}
+
+address ZBarrierSetAssembler::load_barrier_weak_slow_stub(Register reg) {
+  return _load_barrier_weak_slow_stub[reg->encoding()];
 }

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,16 +33,12 @@ class ZLoadBarrierStubC1;
 #endif // COMPILER1
 
 class ZBarrierSetAssembler : public ZBarrierSetAssemblerBase {
+private:
   address _load_barrier_slow_stub[RegisterImpl::number_of_registers];
   address _load_barrier_weak_slow_stub[RegisterImpl::number_of_registers];
 
 public:
-  ZBarrierSetAssembler() :
-    _load_barrier_slow_stub(),
-    _load_barrier_weak_slow_stub() {}
-
-  address load_barrier_slow_stub(Register reg) { return _load_barrier_slow_stub[reg->encoding()]; }
-  address load_barrier_weak_slow_stub(Register reg) { return _load_barrier_weak_slow_stub[reg->encoding()]; }
+  ZBarrierSetAssembler();
 
   virtual void load_at(MacroAssembler* masm,
                        DecoratorSet decorators,
@@ -87,6 +83,9 @@ public:
 #endif // COMPILER1
 
   virtual void barrier_stubs_init();
+
+  address load_barrier_slow_stub(Register reg);
+  address load_barrier_weak_slow_stub(Register reg);
 };
 
 #endif // CPU_X86_GC_Z_ZBARRIERSETASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
+++ b/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
@@ -1,0 +1,155 @@
+//
+// Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+
+source %{
+
+#include "gc/z/zBarrierSetAssembler.hpp"
+
+static void z_load_barrier_slow_reg(MacroAssembler& _masm, Register dst, Address src, bool weak) {
+  assert(dst != r12, "Invalid register");
+  assert(dst != r15, "Invalid register");
+  assert(dst != rsp, "Invalid register");
+
+  const address stub = weak ? ZBarrierSet::assembler()->load_barrier_weak_slow_stub(dst)
+                            : ZBarrierSet::assembler()->load_barrier_slow_stub(dst);
+  __ lea(dst, src);
+  __ call(RuntimeAddress(stub));
+}
+
+%}
+
+// For XMM and YMM enabled processors
+instruct zLoadBarrierSlowRegXmmAndYmm(rRegP dst, memory src, rFlagsReg cr,
+                                      rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
+                                      rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
+                                      rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
+                                      rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15) %{
+
+  match(Set dst (LoadBarrierSlowReg src));
+  predicate(UseAVX <= 2);
+
+  effect(DEF dst, KILL cr,
+         KILL x0, KILL x1, KILL x2, KILL x3,
+         KILL x4, KILL x5, KILL x6, KILL x7,
+         KILL x8, KILL x9, KILL x10, KILL x11,
+         KILL x12, KILL x13, KILL x14, KILL x15);
+
+  format %{ "zLoadBarrierSlowRegXmmAndYmm $dst, $src" %}
+
+  ins_encode %{
+    z_load_barrier_slow_reg(_masm, $dst$$Register, $src$$Address, false /* weak */);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+// For ZMM enabled processors
+instruct zLoadBarrierSlowRegZmm(rRegP dst, memory src, rFlagsReg cr,
+                                rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
+                                rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
+                                rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
+                                rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15,
+                                rxmm16 x16, rxmm17 x17, rxmm18 x18, rxmm19 x19,
+                                rxmm20 x20, rxmm21 x21, rxmm22 x22, rxmm23 x23,
+                                rxmm24 x24, rxmm25 x25, rxmm26 x26, rxmm27 x27,
+                                rxmm28 x28, rxmm29 x29, rxmm30 x30, rxmm31 x31) %{
+
+  match(Set dst (LoadBarrierSlowReg src));
+  predicate(UseAVX == 3);
+
+  effect(DEF dst, KILL cr,
+         KILL x0, KILL x1, KILL x2, KILL x3,
+         KILL x4, KILL x5, KILL x6, KILL x7,
+         KILL x8, KILL x9, KILL x10, KILL x11,
+         KILL x12, KILL x13, KILL x14, KILL x15,
+         KILL x16, KILL x17, KILL x18, KILL x19,
+         KILL x20, KILL x21, KILL x22, KILL x23,
+         KILL x24, KILL x25, KILL x26, KILL x27,
+         KILL x28, KILL x29, KILL x30, KILL x31);
+
+  format %{ "zLoadBarrierSlowRegZmm $dst, $src" %}
+
+  ins_encode %{
+    z_load_barrier_slow_reg(_masm, $dst$$Register, $src$$Address, false /* weak */);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+// For XMM and YMM enabled processors
+instruct zLoadBarrierWeakSlowRegXmmAndYmm(rRegP dst, memory src, rFlagsReg cr,
+                                          rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
+                                          rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
+                                          rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
+                                          rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15) %{
+
+  match(Set dst (LoadBarrierWeakSlowReg src));
+  predicate(UseAVX <= 2);
+
+  effect(DEF dst, KILL cr,
+         KILL x0, KILL x1, KILL x2, KILL x3,
+         KILL x4, KILL x5, KILL x6, KILL x7,
+         KILL x8, KILL x9, KILL x10, KILL x11,
+         KILL x12, KILL x13, KILL x14, KILL x15);
+
+  format %{ "zLoadBarrierWeakSlowRegXmmAndYmm $dst, $src" %}
+
+  ins_encode %{
+    z_load_barrier_slow_reg(_masm, $dst$$Register, $src$$Address, true /* weak */);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+// For ZMM enabled processors
+instruct zLoadBarrierWeakSlowRegZmm(rRegP dst, memory src, rFlagsReg cr,
+                                    rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
+                                    rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
+                                    rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
+                                    rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15,
+                                    rxmm16 x16, rxmm17 x17, rxmm18 x18, rxmm19 x19,
+                                    rxmm20 x20, rxmm21 x21, rxmm22 x22, rxmm23 x23,
+                                    rxmm24 x24, rxmm25 x25, rxmm26 x26, rxmm27 x27,
+                                    rxmm28 x28, rxmm29 x29, rxmm30 x30, rxmm31 x31) %{
+
+  match(Set dst (LoadBarrierWeakSlowReg src));
+  predicate(UseAVX == 3);
+
+  effect(DEF dst, KILL cr,
+         KILL x0, KILL x1, KILL x2, KILL x3,
+         KILL x4, KILL x5, KILL x6, KILL x7,
+         KILL x8, KILL x9, KILL x10, KILL x11,
+         KILL x12, KILL x13, KILL x14, KILL x15,
+         KILL x16, KILL x17, KILL x18, KILL x19,
+         KILL x20, KILL x21, KILL x22, KILL x23,
+         KILL x24, KILL x25, KILL x26, KILL x27,
+         KILL x28, KILL x29, KILL x30, KILL x31);
+
+  format %{ "zLoadBarrierWeakSlowRegZmm $dst, $src" %}
+
+  ins_encode %{
+    z_load_barrier_slow_reg(_masm, $dst$$Register, $src$$Address, true /* weak */);
+  %}
+
+  ins_pipe(pipe_slow);
+%}

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -12661,33 +12661,6 @@ instruct RethrowException()
 // Execute ZGC load barrier (strong) slow path
 //
 
-// When running without XMM regs
-instruct loadBarrierSlowRegNoVec(rRegP dst, memory mem, rFlagsReg cr) %{
-
-  match(Set dst (LoadBarrierSlowReg mem));
-  predicate(MaxVectorSize < 16);
-
-  effect(DEF dst, KILL cr);
-
-  format %{"LoadBarrierSlowRegNoVec $dst, $mem" %}
-  ins_encode %{
-#if INCLUDE_ZGC
-    Register d = $dst$$Register;
-    ZBarrierSetAssembler* bs = (ZBarrierSetAssembler*)BarrierSet::barrier_set()->barrier_set_assembler();
-
-    assert(d != r12, "Can't be R12!");
-    assert(d != r15, "Can't be R15!");
-    assert(d != rsp, "Can't be RSP!");
-
-    __ lea(d, $mem$$Address);
-    __ call(RuntimeAddress(bs->load_barrier_slow_stub(d)));
-#else
-    ShouldNotReachHere();
-#endif
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 // For XMM and YMM enabled processors
 instruct loadBarrierSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
                                      rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
@@ -12696,7 +12669,7 @@ instruct loadBarrierSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
                                      rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15) %{
 
   match(Set dst (LoadBarrierSlowReg mem));
-  predicate((UseSSE > 0) && (UseAVX <= 2) && (MaxVectorSize >= 16));
+  predicate(UseAVX <= 2);
 
   effect(DEF dst, KILL cr,
          KILL x0, KILL x1, KILL x2, KILL x3,
@@ -12704,7 +12677,7 @@ instruct loadBarrierSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
          KILL x8, KILL x9, KILL x10, KILL x11,
          KILL x12, KILL x13, KILL x14, KILL x15);
 
-  format %{"LoadBarrierSlowRegXmm $dst, $mem" %}
+  format %{"LoadBarrierSlowRegXmmAndYmm $dst, $mem" %}
   ins_encode %{
 #if INCLUDE_ZGC
     Register d = $dst$$Register;
@@ -12735,7 +12708,7 @@ instruct loadBarrierSlowRegZmm(rRegP dst, memory mem, rFlagsReg cr,
                                rxmm28 x28, rxmm29 x29, rxmm30 x30, rxmm31 x31) %{
 
   match(Set dst (LoadBarrierSlowReg mem));
-  predicate((UseAVX == 3) && (MaxVectorSize >= 16));
+  predicate(UseAVX == 3);
 
   effect(DEF dst, KILL cr,
          KILL x0, KILL x1, KILL x2, KILL x3,
@@ -12770,33 +12743,6 @@ instruct loadBarrierSlowRegZmm(rRegP dst, memory mem, rFlagsReg cr,
 // Execute ZGC load barrier (weak) slow path
 //
 
-// When running without XMM regs
-instruct loadBarrierWeakSlowRegNoVec(rRegP dst, memory mem, rFlagsReg cr) %{
-
-  match(Set dst (LoadBarrierSlowReg mem));
-  predicate(MaxVectorSize < 16);
-
-  effect(DEF dst, KILL cr);
-
-  format %{"LoadBarrierSlowRegNoVec $dst, $mem" %}
-  ins_encode %{
-#if INCLUDE_ZGC
-    Register d = $dst$$Register;
-    ZBarrierSetAssembler* bs = (ZBarrierSetAssembler*)BarrierSet::barrier_set()->barrier_set_assembler();
-
-    assert(d != r12, "Can't be R12!");
-    assert(d != r15, "Can't be R15!");
-    assert(d != rsp, "Can't be RSP!");
-
-    __ lea(d, $mem$$Address);
-    __ call(RuntimeAddress(bs->load_barrier_weak_slow_stub(d)));
-#else
-    ShouldNotReachHere();
-#endif
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 // For XMM and YMM enabled processors
 instruct loadBarrierWeakSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
                                          rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
@@ -12805,7 +12751,7 @@ instruct loadBarrierWeakSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
                                          rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15) %{
 
   match(Set dst (LoadBarrierWeakSlowReg mem));
-  predicate((UseSSE > 0) && (UseAVX <= 2) && (MaxVectorSize >= 16));
+  predicate(UseAVX <= 2);
 
   effect(DEF dst, KILL cr,
          KILL x0, KILL x1, KILL x2, KILL x3,
@@ -12813,7 +12759,7 @@ instruct loadBarrierWeakSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
          KILL x8, KILL x9, KILL x10, KILL x11,
          KILL x12, KILL x13, KILL x14, KILL x15);
 
-  format %{"LoadBarrierWeakSlowRegXmm $dst, $mem" %}
+  format %{"LoadBarrierWeakSlowRegXmmAndYmm $dst, $mem" %}
   ins_encode %{
 #if INCLUDE_ZGC
     Register d = $dst$$Register;
@@ -12844,7 +12790,7 @@ instruct loadBarrierWeakSlowRegZmm(rRegP dst, memory mem, rFlagsReg cr,
                                    rxmm28 x28, rxmm29 x29, rxmm30 x30, rxmm31 x31) %{
 
   match(Set dst (LoadBarrierWeakSlowReg mem));
-  predicate((UseAVX == 3) && (MaxVectorSize >= 16));
+  predicate(UseAVX == 3);
 
   effect(DEF dst, KILL cr,
          KILL x0, KILL x1, KILL x2, KILL x3,

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -536,12 +536,6 @@ reg_class int_rdi_reg(RDI);
 // Singleton class for instruction pointer
 // reg_class ip_reg(RIP);
 
-%}
-
-source_hpp %{
-#if INCLUDE_ZGC
-#include "gc/z/zBarrierSetAssembler.hpp"
-#endif
 %}
 
 //----------SOURCE BLOCK-------------------------------------------------------
@@ -12655,170 +12649,6 @@ instruct RethrowException()
   format %{ "jmp     rethrow_stub" %}
   ins_encode(enc_rethrow);
   ins_pipe(pipe_jmp);
-%}
-
-//
-// Execute ZGC load barrier (strong) slow path
-//
-
-// For XMM and YMM enabled processors
-instruct loadBarrierSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
-                                     rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
-                                     rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
-                                     rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
-                                     rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15) %{
-
-  match(Set dst (LoadBarrierSlowReg mem));
-  predicate(UseAVX <= 2);
-
-  effect(DEF dst, KILL cr,
-         KILL x0, KILL x1, KILL x2, KILL x3,
-         KILL x4, KILL x5, KILL x6, KILL x7,
-         KILL x8, KILL x9, KILL x10, KILL x11,
-         KILL x12, KILL x13, KILL x14, KILL x15);
-
-  format %{"LoadBarrierSlowRegXmmAndYmm $dst, $mem" %}
-  ins_encode %{
-#if INCLUDE_ZGC
-    Register d = $dst$$Register;
-    ZBarrierSetAssembler* bs = (ZBarrierSetAssembler*)BarrierSet::barrier_set()->barrier_set_assembler();
-
-    assert(d != r12, "Can't be R12!");
-    assert(d != r15, "Can't be R15!");
-    assert(d != rsp, "Can't be RSP!");
-
-    __ lea(d, $mem$$Address);
-    __ call(RuntimeAddress(bs->load_barrier_slow_stub(d)));
-#else
-    ShouldNotReachHere();
-#endif
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// For ZMM enabled processors
-instruct loadBarrierSlowRegZmm(rRegP dst, memory mem, rFlagsReg cr,
-                               rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
-                               rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
-                               rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
-                               rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15,
-                               rxmm16 x16, rxmm17 x17, rxmm18 x18, rxmm19 x19,
-                               rxmm20 x20, rxmm21 x21, rxmm22 x22, rxmm23 x23,
-                               rxmm24 x24, rxmm25 x25, rxmm26 x26, rxmm27 x27,
-                               rxmm28 x28, rxmm29 x29, rxmm30 x30, rxmm31 x31) %{
-
-  match(Set dst (LoadBarrierSlowReg mem));
-  predicate(UseAVX == 3);
-
-  effect(DEF dst, KILL cr,
-         KILL x0, KILL x1, KILL x2, KILL x3,
-         KILL x4, KILL x5, KILL x6, KILL x7,
-         KILL x8, KILL x9, KILL x10, KILL x11,
-         KILL x12, KILL x13, KILL x14, KILL x15,
-         KILL x16, KILL x17, KILL x18, KILL x19,
-         KILL x20, KILL x21, KILL x22, KILL x23,
-         KILL x24, KILL x25, KILL x26, KILL x27,
-         KILL x28, KILL x29, KILL x30, KILL x31);
-
-  format %{"LoadBarrierSlowRegZmm $dst, $mem" %}
-  ins_encode %{
-#if INCLUDE_ZGC
-    Register d = $dst$$Register;
-    ZBarrierSetAssembler* bs = (ZBarrierSetAssembler*)BarrierSet::barrier_set()->barrier_set_assembler();
-
-    assert(d != r12, "Can't be R12!");
-    assert(d != r15, "Can't be R15!");
-    assert(d != rsp, "Can't be RSP!");
-
-    __ lea(d, $mem$$Address);
-    __ call(RuntimeAddress(bs->load_barrier_slow_stub(d)));
-#else
-    ShouldNotReachHere();
-#endif
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-//
-// Execute ZGC load barrier (weak) slow path
-//
-
-// For XMM and YMM enabled processors
-instruct loadBarrierWeakSlowRegXmmAndYmm(rRegP dst, memory mem, rFlagsReg cr,
-                                         rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
-                                         rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
-                                         rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
-                                         rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15) %{
-
-  match(Set dst (LoadBarrierWeakSlowReg mem));
-  predicate(UseAVX <= 2);
-
-  effect(DEF dst, KILL cr,
-         KILL x0, KILL x1, KILL x2, KILL x3,
-         KILL x4, KILL x5, KILL x6, KILL x7,
-         KILL x8, KILL x9, KILL x10, KILL x11,
-         KILL x12, KILL x13, KILL x14, KILL x15);
-
-  format %{"LoadBarrierWeakSlowRegXmmAndYmm $dst, $mem" %}
-  ins_encode %{
-#if INCLUDE_ZGC
-    Register d = $dst$$Register;
-    ZBarrierSetAssembler* bs = (ZBarrierSetAssembler*)BarrierSet::barrier_set()->barrier_set_assembler();
-
-    assert(d != r12, "Can't be R12!");
-    assert(d != r15, "Can't be R15!");
-    assert(d != rsp, "Can't be RSP!");
-
-    __ lea(d,$mem$$Address);
-    __ call(RuntimeAddress(bs->load_barrier_weak_slow_stub(d)));
-#else
-    ShouldNotReachHere();
-#endif
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// For ZMM enabled processors
-instruct loadBarrierWeakSlowRegZmm(rRegP dst, memory mem, rFlagsReg cr,
-                                   rxmm0 x0, rxmm1 x1, rxmm2 x2,rxmm3 x3,
-                                   rxmm4 x4, rxmm5 x5, rxmm6 x6, rxmm7 x7,
-                                   rxmm8 x8, rxmm9 x9, rxmm10 x10, rxmm11 x11,
-                                   rxmm12 x12, rxmm13 x13, rxmm14 x14, rxmm15 x15,
-                                   rxmm16 x16, rxmm17 x17, rxmm18 x18, rxmm19 x19,
-                                   rxmm20 x20, rxmm21 x21, rxmm22 x22, rxmm23 x23,
-                                   rxmm24 x24, rxmm25 x25, rxmm26 x26, rxmm27 x27,
-                                   rxmm28 x28, rxmm29 x29, rxmm30 x30, rxmm31 x31) %{
-
-  match(Set dst (LoadBarrierWeakSlowReg mem));
-  predicate(UseAVX == 3);
-
-  effect(DEF dst, KILL cr,
-         KILL x0, KILL x1, KILL x2, KILL x3,
-         KILL x4, KILL x5, KILL x6, KILL x7,
-         KILL x8, KILL x9, KILL x10, KILL x11,
-         KILL x12, KILL x13, KILL x14, KILL x15,
-         KILL x16, KILL x17, KILL x18, KILL x19,
-         KILL x20, KILL x21, KILL x22, KILL x23,
-         KILL x24, KILL x25, KILL x26, KILL x27,
-         KILL x28, KILL x29, KILL x30, KILL x31);
-
-  format %{"LoadBarrierWeakSlowRegZmm $dst, $mem" %}
-  ins_encode %{
-#if INCLUDE_ZGC
-    Register d = $dst$$Register;
-    ZBarrierSetAssembler* bs = (ZBarrierSetAssembler*)BarrierSet::barrier_set()->barrier_set_assembler();
-
-    assert(d != r12, "Can't be R12!");
-    assert(d != r15, "Can't be R15!");
-    assert(d != rsp, "Can't be RSP!");
-
-    __ lea(d,$mem$$Address);
-    __ call(RuntimeAddress(bs->load_barrier_weak_slow_stub(d)));
-#else
-    ShouldNotReachHere();
-#endif
-  %}
-  ins_pipe(pipe_slow);
 %}
 
 // ============================================================================

--- a/src/hotspot/os_cpu/linux_x86/gc/z/zArguments_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/gc/z/zArguments_linux_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #include "utilities/debug.hpp"
 
 void ZArguments::initialize_platform() {
+#ifdef COMPILER2
   // The C2 barrier slow path expects vector registers to be least
   // 16 bytes wide, which is the minimum width available on all
   // x86-64 systems. However, the user could have speficied a lower
@@ -37,4 +38,5 @@ void ZArguments::initialize_platform() {
     warning("ZGC requires MaxVectorSize to be at least 16");
     FLAG_SET_DEFAULT(MaxVectorSize, 16);
   }
+#endif
 }

--- a/src/hotspot/os_cpu/linux_x86/gc/z/zArguments_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/gc/z/zArguments_linux_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,21 +21,20 @@
  * questions.
  */
 
-#ifndef SHARE_GC_Z_ZARGUMENTS_HPP
-#define SHARE_GC_Z_ZARGUMENTS_HPP
+#include "precompiled.hpp"
+#include "gc/z/zArguments.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/globals_extension.hpp"
+#include "utilities/debug.hpp"
 
-#include "gc/shared/gcArguments.hpp"
-
-class CollectedHeap;
-
-class ZArguments : public GCArguments {
-private:
-  void initialize_platform();
-
-public:
-  virtual void initialize();
-  virtual size_t conservative_max_heap_alignment();
-  virtual CollectedHeap* create_heap();
-};
-
-#endif // SHARE_GC_Z_ZARGUMENTS_HPP
+void ZArguments::initialize_platform() {
+  // The C2 barrier slow path expects vector registers to be least
+  // 16 bytes wide, which is the minimum width available on all
+  // x86-64 systems. However, the user could have speficied a lower
+  // number on the command-line, in which case we print a warning
+  // and raise it to 16.
+  if (MaxVectorSize < 16) {
+    warning("ZGC requires MaxVectorSize to be at least 16");
+    FLAG_SET_DEFAULT(MaxVectorSize, 16);
+  }
+}

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -19,7 +19,6 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- *
  */
 
 #include "precompiled.hpp"
@@ -95,6 +94,9 @@ void ZArguments::initialize() {
   // Verification of stacks not (yet) supported, for the same reason
   // we need fixup_partial_loads
   DEBUG_ONLY(FLAG_SET_DEFAULT(VerifyStack, false));
+
+  // Initialize platform specific arguments
+  initialize_platform();
 }
 
 CollectedHeap* ZArguments::create_heap() {

--- a/src/hotspot/share/gc/z/zForwardingTable.cpp
+++ b/src/hotspot/share/gc/z/zForwardingTable.cpp
@@ -38,11 +38,18 @@ void ZForwardingTable::setup(size_t live_objects) {
   _size = ZUtils::round_up_power_of_2(live_objects * 2);
   _table = MallocArrayAllocator<ZForwardingTableEntry>::allocate(_size, mtGC);
 
-  // Clear table
-  memset(_table, ZForwardingTableEntry::empty(), _size * sizeof(ZForwardingTableEntry));
+  // Construct table entries
+  for (size_t i = 0; i < _size; i++) {
+    ::new (_table + i) ZForwardingTableEntry();
+  }
 }
 
 void ZForwardingTable::reset() {
+  // Destruct table entries
+  for (size_t i = 0; i < _size; i++) {
+    (_table + i)->~ZForwardingTableEntry();
+  }
+
   // Free table
   MallocArrayAllocator<ZForwardingTableEntry>::free(_table);
   _table = NULL;

--- a/src/hotspot/share/gc/z/zForwardingTableEntry.hpp
+++ b/src/hotspot/share/gc/z/zForwardingTableEntry.hpp
@@ -52,6 +52,10 @@ private:
 
   uint64_t _entry;
 
+  static uintptr_t empty() {
+    return (uintptr_t)-1;
+  }
+
 public:
   ZForwardingTableEntry() :
       _entry(empty()) {}
@@ -59,10 +63,6 @@ public:
   ZForwardingTableEntry(size_t from_index, size_t to_offset) :
       _entry(field_from_index::encode(from_index) |
              field_to_offset::encode(to_offset)) {}
-
-  static uintptr_t empty() {
-    return (uintptr_t)-1;
-  }
 
   bool is_empty() const {
     return _entry == empty();

--- a/src/hotspot/share/gc/z/zObjectAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.cpp
@@ -131,7 +131,8 @@ uintptr_t ZObjectAllocator::alloc_medium_object(size_t size, ZAllocationFlags fl
 }
 
 uintptr_t ZObjectAllocator::alloc_small_object_from_nonworker(size_t size, ZAllocationFlags flags) {
-  assert(ZThread::is_java() || ZThread::is_vm(), "Should be a Java or VM thread");
+  assert(ZThread::is_java() || ZThread::is_vm() || ZThread::is_runtime_worker(),
+         "Should be a Java, VM or Runtime worker thread");
 
   // Non-worker small page allocation can never use the reserve
   flags.set_no_reserve();
@@ -196,7 +197,8 @@ uintptr_t ZObjectAllocator::alloc_object(size_t size) {
 }
 
 uintptr_t ZObjectAllocator::alloc_object_for_relocation(size_t size) {
-  assert(ZThread::is_java() || ZThread::is_worker() || ZThread::is_vm(), "Unknown thread");
+  assert(ZThread::is_java() || ZThread::is_vm() || ZThread::is_worker() || ZThread::is_runtime_worker(),
+         "Unknown thread");
 
   ZAllocationFlags flags;
   flags.set_relocation();

--- a/src/hotspot/share/gc/z/zReferenceProcessor.hpp
+++ b/src/hotspot/share/gc/z/zReferenceProcessor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,12 +52,11 @@ private:
   const char* reference_type_name(ReferenceType type) const;
   volatile oop* reference_referent_addr(oop obj) const;
   oop reference_referent(oop obj) const;
-  bool is_reference_inactive(oop obj) const;
+  bool is_inactive_final_reference(oop obj, ReferenceType type) const;
   bool is_referent_strongly_alive_or_null(oop obj, ReferenceType type) const;
   bool is_referent_softly_alive(oop obj, ReferenceType type) const;
   bool should_drop_reference(oop obj, ReferenceType type) const;
   bool should_mark_referent(ReferenceType type) const;
-  bool should_clear_referent(ReferenceType type) const;
   void keep_referent_alive(oop obj, ReferenceType type) const;
 
   void discover(oop obj, ReferenceType type);

--- a/src/hotspot/share/gc/z/zRuntimeWorkers.cpp
+++ b/src/hotspot/share/gc/z/zRuntimeWorkers.cpp
@@ -22,7 +22,43 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/workgroup.hpp"
 #include "gc/z/zRuntimeWorkers.hpp"
+#include "gc/z/zThread.hpp"
+#include "runtime/mutexLocker.hpp"
+
+class ZRuntimeWorkersInitializeTask : public AbstractGangTask {
+private:
+  const uint _nworkers;
+  uint       _started;
+  Monitor    _monitor;
+
+public:
+  ZRuntimeWorkersInitializeTask(uint nworkers) :
+      AbstractGangTask("ZRuntimeWorkersInitializeTask"),
+      _nworkers(nworkers),
+      _started(0),
+      _monitor(Monitor::leaf,
+               "ZRuntimeWorkersInitialize",
+               false /* allow_vm_block */,
+               Monitor::_safepoint_check_never) {}
+
+  virtual void work(uint worker_id) {
+    // Register as runtime worker
+    ZThread::set_runtime_worker();
+
+    // Wait for all threads to start
+    MonitorLockerEx ml(&_monitor, Monitor::_no_safepoint_check_flag);
+    if (++_started == _nworkers) {
+      // All threads started
+      ml.notify_all();
+    } else {
+      while (_started != _nworkers) {
+        ml.wait(Monitor::_no_safepoint_check_flag);
+      }
+    }
+  }
+};
 
 ZRuntimeWorkers::ZRuntimeWorkers() :
     _workers("RuntimeWorker",
@@ -35,6 +71,15 @@ ZRuntimeWorkers::ZRuntimeWorkers() :
   // Initialize worker threads
   _workers.initialize_workers();
   _workers.update_active_workers(nworkers());
+  if (_workers.active_workers() != nworkers()) {
+    vm_exit_during_initialization("Failed to create ZRuntimeWorkers");
+  }
+
+  // Execute task to register threads as runtime workers. This also
+  // helps reduce latency in early safepoints, which otherwise would
+  // have to take on any warmup costs.
+  ZRuntimeWorkersInitializeTask task(nworkers());
+  _workers.run_task(&task);
 }
 
 uint ZRuntimeWorkers::nworkers() const {

--- a/src/hotspot/share/gc/z/zThread.cpp
+++ b/src/hotspot/share/gc/z/zThread.cpp
@@ -31,6 +31,7 @@ __thread uintptr_t ZThread::_id;
 __thread bool      ZThread::_is_vm;
 __thread bool      ZThread::_is_java;
 __thread bool      ZThread::_is_worker;
+__thread bool      ZThread::_is_runtime_worker;
 __thread uint      ZThread::_worker_id;
 
 void ZThread::initialize() {
@@ -40,7 +41,8 @@ void ZThread::initialize() {
   _id = (uintptr_t)thread;
   _is_vm = thread->is_VM_thread();
   _is_java = thread->is_Java_thread();
-  _is_worker = thread->is_Worker_thread();
+  _is_worker = false;
+  _is_runtime_worker = false;
   _worker_id = (uint)-1;
 }
 
@@ -54,6 +56,16 @@ const char* ZThread::name() {
   }
 
   return "Unknown";
+}
+
+void ZThread::set_worker() {
+  ensure_initialized();
+  _is_worker = true;
+}
+
+void ZThread::set_runtime_worker() {
+  ensure_initialized();
+  _is_runtime_worker = true;
 }
 
 bool ZThread::has_worker_id() {

--- a/src/hotspot/share/gc/z/zThread.hpp
+++ b/src/hotspot/share/gc/z/zThread.hpp
@@ -29,6 +29,8 @@
 
 class ZThread : public AllStatic {
   friend class ZTask;
+  friend class ZWorkersInitializeTask;
+  friend class ZRuntimeWorkersInitializeTask;
 
 private:
   static __thread bool      _initialized;
@@ -36,6 +38,7 @@ private:
   static __thread bool      _is_vm;
   static __thread bool      _is_java;
   static __thread bool      _is_worker;
+  static __thread bool      _is_runtime_worker;
   static __thread uint      _worker_id;
 
   static void initialize();
@@ -45,6 +48,9 @@ private:
       initialize();
     }
   }
+
+  static void set_worker();
+  static void set_runtime_worker();
 
   static bool has_worker_id();
   static void set_worker_id(uint worker_id);
@@ -71,6 +77,11 @@ public:
   static bool is_worker() {
     ensure_initialized();
     return _is_worker;
+  }
+
+  static bool is_runtime_worker() {
+    ensure_initialized();
+    return _is_runtime_worker;
   }
 
   static uint worker_id() {

--- a/src/hotspot/share/gc/z/zWorkers.cpp
+++ b/src/hotspot/share/gc/z/zWorkers.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "gc/z/zGlobals.hpp"
 #include "gc/z/zTask.hpp"
+#include "gc/z/zThread.hpp"
 #include "gc/z/zWorkers.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/mutexLocker.hpp"
@@ -64,20 +65,26 @@ uint ZWorkers::calculate_nconcurrent() {
   return calculate_nworkers(12.5);
 }
 
-class ZWorkersWarmupTask : public ZTask {
+class ZWorkersInitializeTask : public ZTask {
 private:
   const uint _nworkers;
   uint       _started;
   Monitor    _monitor;
 
 public:
-  ZWorkersWarmupTask(uint nworkers) :
-      ZTask("ZWorkersWarmupTask"),
+  ZWorkersInitializeTask(uint nworkers) :
+      ZTask("ZWorkersInitializeTask"),
       _nworkers(nworkers),
       _started(0),
-      _monitor(Monitor::leaf, "ZWorkersWarmup", false, Monitor::_safepoint_check_never) {}
+      _monitor(Monitor::leaf,
+               "ZWorkersInitialize",
+               false /* allow_vm_block */,
+               Monitor::_safepoint_check_never) {}
 
   virtual void work() {
+    // Register as worker
+    ZThread::set_worker();
+
     // Wait for all threads to start
     MonitorLockerEx ml(&_monitor, Monitor::_no_safepoint_check_flag);
     if (++_started == _nworkers) {
@@ -107,10 +114,10 @@ ZWorkers::ZWorkers() :
     vm_exit_during_initialization("Failed to create ZWorkers");
   }
 
-  // Warm up worker threads by having them execute a dummy task.
-  // This helps reduce latency in early GC pauses, which otherwise
-  // would have to take on any warmup costs.
-  ZWorkersWarmupTask task(nworkers());
+  // Execute task to register threads as workers. This also helps
+  // reduce latency in early GC pauses, which otherwise would have
+  // to take on any warmup costs.
+  ZWorkersInitializeTask task(nworkers());
   run(&task, nworkers());
 }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/JMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/JMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,7 @@ public class JMap extends Tool {
             hgw.write(fileName);
             System.out.println("heap written to " + fileName);
             return true;
-        } catch (IOException exp) {
+        } catch (IOException | RuntimeException exp) {
             System.err.println(exp.getMessage());
             return false;
         }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -32,6 +32,7 @@ import sun.jvm.hotspot.memory.*;
 import sun.jvm.hotspot.oops.*;
 import sun.jvm.hotspot.runtime.*;
 import sun.jvm.hotspot.classfile.*;
+import sun.jvm.hotspot.gc.z.ZCollectedHeap;
 
 /*
  * This class writes Java heap in hprof binary format. This format is
@@ -388,11 +389,15 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
     }
 
     public synchronized void write(String fileName) throws IOException {
+        VM vm = VM.getVM();
+        if (vm.getUniverse().heap() instanceof ZCollectedHeap) {
+            throw new RuntimeException("This operation is not supported with ZGC.");
+        }
+
         // open file stream and create buffered data output stream
         fos = new FileOutputStream(fileName);
         out = new DataOutputStream(new BufferedOutputStream(fos));
 
-        VM vm = VM.getVM();
         dbg = vm.getDebugger();
         objectHeap = vm.getObjectHeap();
 

--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -37,6 +37,7 @@ import jdk.test.lib.classloader.GeneratingClassLoader;
 import jdk.test.lib.hprof.HprofParser;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Utils;
 import jtreg.SkippedException;
 
 import java.io.File;
@@ -134,10 +135,24 @@ public class TestJmapCore {
         System.out.println(out.getStdout());
         System.err.println(out.getStderr());
 
-        Asserts.assertTrue(dumpFile.exists() && dumpFile.isFile(),
-                "Could not find dump file " + dumpFile.getAbsolutePath());
+        if (dumpFile.exists() && dumpFile.isFile()) {
+            HprofParser.parse(dumpFile);
+        } else {
+            boolean ZGCUsed = false;
 
-        HprofParser.parse(dumpFile);
+            for (String opt: Utils.getFilteredTestJavaOpts()) {
+                if (opt.contains("+UseZGC")) {
+                    ZGCUsed = true;
+                    break;
+                }
+            }
+
+            if (!ZGCUsed) {
+                throw new RuntimeException(
+                    "Could not find dump file " + dumpFile.getAbsolutePath());
+            }
+        }
+
         System.out.println("PASSED");
     }
 }


### PR DESCRIPTION
8214377: ZGC: Don't use memset to initialize array of ZForwardingTableEntry
8215487: ZGC: ZRuntimeWorkers incorrectly identify themselves as ZWorkers
8215985: ZGC: Simplify reference processing in light of JDK-8175797
8215547: ZGC: Fix incorrect match rule for loadBarrierWeakSlowRegNoVec
8217856: ZGC: Break out C2 matching rules into separate AD file
8216385: ZGC: Fix building without C2
8216372: ZGC: Put C2 load barrier stub routines in separate codeblobs
8213323: sa/TestJmapCoreMetaspace.java and sa/TestJmapCore.java fail with ZGC
8217258: ZGC: Minor cleanup of ZBarrierSetAssembler

@sandlerwang please review 8215547 by verifying if VectorAPI or other parts of JVM will be influenced since `rxmm`s are changed
@mmyxym @linade @leveretconey please review the patches that mention your id

Thanks