### PR TITLE
[Backport] [GC] Backport GC interface for ZGC

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -1473,6 +1473,17 @@ bool ZBarrierSetC2::final_graph_reshaping(Compile* compile, Node* n, uint opcode
   return handled;
 }
 
+bool ZBarrierSetC2::matcher_find_shared_visit(Matcher* matcher, Matcher::MStack& mstack, Node* n, uint opcode, bool& mem_op, int& mem_addr_idx) {
+  if (opcode == Op_CallLeaf &&
+      (n->as_Call()->entry_point() == ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded_addr() ||
+       n->as_Call()->entry_point() == ZBarrierSetRuntime::load_barrier_on_weak_oop_field_preloaded_addr())) {
+    mem_op = true;
+    mem_addr_idx = TypeFunc::Parms + 1;
+    return true;
+  }
+  return false;
+}
+
 // == Verification ==
 
 #ifdef ASSERT

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "opto/compile.hpp"
 #include "opto/castnode.hpp"
+#include "opto/escape.hpp"
 #include "opto/graphKit.hpp"
 #include "opto/idealKit.hpp"
 #include "opto/loopnode.hpp"
@@ -1556,3 +1557,44 @@ void ZBarrierSetC2::verify_gc_barriers(bool post_parse) const {
 }
 
 #endif
+
+bool ZBarrierSetC2::escape_add_to_con_graph(ConnectionGraph* conn_graph, PhaseGVN* gvn, Unique_Node_List* delayed_worklist, Node* n, uint opcode) {
+  switch (opcode) {
+    case Op_LoadBarrierSlowReg:
+    case Op_LoadBarrierWeakSlowReg:
+      conn_graph->add_objload_to_connection_graph(n, delayed_worklist);
+      return true;
+    case Op_Proj:
+      if (n->as_Proj()->_con == LoadBarrierNode::Oop && n->in(0)->is_LoadBarrier()) {
+        conn_graph->add_local_var_and_edge(n, PointsToNode::NoEscape, n->in(0)->in(LoadBarrierNode::Oop),
+                                           delayed_worklist);
+        return true;
+      }
+    default:
+      break;
+  }
+  return false;
+}
+
+bool ZBarrierSetC2::escape_add_final_edges(ConnectionGraph* conn_graph, PhaseGVN* gvn, Node* n, uint opcode) {
+  switch (opcode) {
+    case Op_LoadBarrierSlowReg:
+    case Op_LoadBarrierWeakSlowReg: {
+      const Type *t = gvn->type(n);
+      if (t->make_ptr() != NULL) {
+        Node *adr = n->in(MemNode::Address);
+        conn_graph->add_local_var_and_edge(n, PointsToNode::NoEscape, adr, NULL);
+        return true;
+      }
+    }
+    case Op_Proj: {
+      if (n->as_Proj()->_con == LoadBarrierNode::Oop && n->in(0)->is_LoadBarrier()) {
+        conn_graph->add_local_var_and_edge(n, PointsToNode::NoEscape, n->in(0)->in(LoadBarrierNode::Oop), NULL);
+        return true;
+      }
+    }
+    default:
+      break;
+  }
+  return false;
+}

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -1450,6 +1450,29 @@ Node* ZBarrierSetC2::step_over_gc_barrier(Node* c) const {
   return c;
 }
 
+bool ZBarrierSetC2::final_graph_reshaping(Compile* compile, Node* n, uint opcode) {
+  bool handled;
+  switch (opcode) {
+    case Op_LoadBarrierSlowReg:
+    case Op_LoadBarrierWeakSlowReg:
+#ifdef ASSERT
+      if (VerifyOptoOopOffsets) {
+        MemNode* mem  = n->as_Mem();
+        // Check to see if address types have grounded out somehow.
+        const TypeInstPtr* tp = mem->in(MemNode::Address)->bottom_type()->isa_instptr();
+        ciInstanceKlass* k = tp->klass()->as_instance_klass();
+        bool oop_offset_is_sane = k->contains_field_offset(tp->offset());
+        assert(!tp || oop_offset_is_sane, "");
+      }
+#endif
+      handled = true;
+      break;
+    default:
+      handled = false;
+  }
+  return handled;
+}
+
 // == Verification ==
 
 #ifdef ASSERT

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -1586,6 +1586,7 @@ bool ZBarrierSetC2::escape_add_final_edges(ConnectionGraph* conn_graph, PhaseGVN
         conn_graph->add_local_var_and_edge(n, PointsToNode::NoEscape, adr, NULL);
         return true;
       }
+      break;
     }
     case Op_Proj: {
       if (n->as_Proj()->_con == LoadBarrierNode::Oop && n->in(0)->is_LoadBarrier()) {

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -209,6 +209,9 @@ public:
 
   static bool final_graph_reshaping(Compile* compile, Node* n, uint opcode);
 
+  static bool matcher_find_shared_visit(Matcher* matcher, Matcher::MStack& mstack, Node* n, uint opcode, bool& mem_op, int& mem_addr_idx);
+  static bool matcher_find_shared_post_visit(Matcher* matcher, Node* n, uint opcode) { return false; }
+
 #ifdef ASSERT
   virtual void verify_gc_barriers(bool post_parse) const;
 #endif

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -207,6 +207,8 @@ public:
   static void find_dominating_barriers(PhaseIterGVN& igvn);
   static void loop_optimize_gc_barrier(PhaseIdealLoop* phase, Node* node, bool last_round);
 
+  static bool final_graph_reshaping(Compile* compile, Node* n, uint opcode);
+
 #ifdef ASSERT
   virtual void verify_gc_barriers(bool post_parse) const;
 #endif

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -210,6 +210,9 @@ public:
 #ifdef ASSERT
   virtual void verify_gc_barriers(bool post_parse) const;
 #endif
+
+  static bool escape_add_to_con_graph(ConnectionGraph* conn_graph, PhaseGVN* gvn, Unique_Node_List* delayed_worklist, Node* n, uint opcode);
+  static bool escape_add_final_edges(ConnectionGraph* conn_graph, PhaseGVN* gvn, Node* n, uint opcode);
 };
 
 #endif // SHARE_GC_Z_C2_ZBARRIERSETC2_HPP

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2833,6 +2833,9 @@ void Compile::final_graph_reshaping_impl( Node *n, Final_Reshape_Counts &frc) {
   }
 #endif
   // Count FPU ops and common calls, implements item (3)
+#if INCLUDE_ZGC
+  if (!(UseZGC && ZBarrierSetC2::final_graph_reshaping(this, n, nop))) {
+#endif
   switch( nop ) {
   // Count all float operations that may use FPU
   case Op_AddF:
@@ -2990,10 +2993,6 @@ void Compile::final_graph_reshaping_impl( Node *n, Final_Reshape_Counts &frc) {
   case Op_LoadL_unaligned:
   case Op_LoadPLocked:
   case Op_LoadP:
-#if INCLUDE_ZGC
-  case Op_LoadBarrierSlowReg:
-  case Op_LoadBarrierWeakSlowReg:
-#endif
   case Op_LoadN:
   case Op_LoadRange:
   case Op_LoadS: {
@@ -3546,6 +3545,7 @@ void Compile::final_graph_reshaping_impl( Node *n, Final_Reshape_Counts &frc) {
     assert( nop != Op_ProfileBoolean, "should be eliminated during IGVN");
     break;
   }
+ZGC_ONLY(})
 
   // Collect CFG split points
   if (n->is_MultiBranch() && !n->is_RangeCheck()) {

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -28,6 +28,9 @@
 #include "opto/addnode.hpp"
 #include "opto/node.hpp"
 #include "utilities/growableArray.hpp"
+#if INCLUDE_ZGC
+#include "gc/z/c2/zBarrierSetC2.hpp"
+#endif
 
 //
 // Adaptation for C2 of the escape analysis algorithm described in:
@@ -319,6 +322,9 @@ public:
 
 class ConnectionGraph: public ResourceObj {
   friend class PointsToNode;
+#if INCLUDE_ZGC
+  friend class ZBarrierSetC2;
+#endif
 private:
   GrowableArray<PointsToNode*>  _nodes; // Map from ideal nodes to
                                         // ConnectionGraph nodes.


### PR DESCRIPTION
I am splitting #89 into three pull requests.

1. 8213615: GC/C2 abstraction for escape analysis (only ZGC part)
2. 8217503: ZGC: Fix fall through bug in ZBarrierSetC2::escape_add_final_edges()
3. 8213489: GC/C2 abstraction for Compile::final_graph_reshaping() (ZGC-only)
4. 8213746: GC/C2 abstraction for C2 matcher **(introduced in Apr.26)**

1-3 have been ported in #92.
You can only review 4 (8213746) since 1-3 were cleanly cherry-picked.