### PR TITLE
[GC] ZGC: Make "High Usage" threshold adjustable

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -193,7 +193,7 @@ bool ZDirector::rule_high_usage() const {
   log_debug(gc, director)("Rule: High Usage, Free: " SIZE_FORMAT "MB(%.1f%%)",
                           free / M, free_percent);
 
-  return free_percent <= 5.0;
+  return free_percent <= 100.0 - ZHighUsagePercent;
 }
 
 GCCause::Cause ZDirector::make_gc_decision() const {

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -70,6 +70,10 @@
           "Uncommit memory if it has been unused for the specified "        \
           "amount of time (in seconds)")                                    \
                                                                             \
+  experimental(double, ZHighUsagePercent, 95.0,                             \
+          "Percentage of heap usage for ZGC high usage rule")               \
+          range(0.0, 100.0)                                                 \
+                                                                            \
   diagnostic(uint, ZStatisticsInterval, 10,                                 \
           "Time between statistics print outs (in seconds)")                \
           range(1, (uint)-1)                                                \


### PR DESCRIPTION
Summary: Introduce option -XX:ZHighUsagePercent
  - The option sets the percentage of heap usage for ZGC High Usage rule
  - The option sets a decimal number (95.0 by default, which does not
    change the behavior of the original High Usage rule)

Test Plan: gc/z/TestHighUsage.java

Reviewers: weixlu, mmyxym

Issue: https://github.com/alibaba/dragonwell11/pull/114


The original patch is from https://code.aone.alibaba-inc.com/xcode/jdk11/commit/9e2d3b12d00d96e3f5c4ba91164af5e6c6f541b5