### PR TITLE
[GC] Backport 8210832 for ZGC ZConditionLock

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -2244,5 +2244,79 @@ void Parker::unpark() {
   }
 }
 
+#if INCLUDE_ZGC
+
+// Platform Monitor implementation
+
+os::PlatformMonitor::PlatformMonitor() {
+  int status = pthread_cond_init(&_cond, _condAttr);
+  assert_status(status == 0, status, "cond_init");
+  status = pthread_mutex_init(&_mutex, _mutexAttr);
+  assert_status(status == 0, status, "mutex_init");
+}
+
+os::PlatformMonitor::~PlatformMonitor() {
+  int status = pthread_cond_destroy(&_cond);
+  assert_status(status == 0, status, "cond_destroy");
+  status = pthread_mutex_destroy(&_mutex);
+  assert_status(status == 0, status, "mutex_destroy");
+}
+
+void os::PlatformMonitor::lock() {
+  int status = pthread_mutex_lock(&_mutex);
+  assert_status(status == 0, status, "mutex_lock");
+}
+
+void os::PlatformMonitor::unlock() {
+  int status = pthread_mutex_unlock(&_mutex);
+  assert_status(status == 0, status, "mutex_unlock");
+}
+
+bool os::PlatformMonitor::try_lock() {
+  int status = pthread_mutex_trylock(&_mutex);
+  assert_status(status == 0 || status == EBUSY, status, "mutex_trylock");
+  return status == 0;
+}
+
+// Must already be locked
+int os::PlatformMonitor::wait(jlong millis) {
+  assert(millis >= 0, "negative timeout");
+  if (millis > 0) {
+    struct timespec abst;
+    // We have to watch for overflow when converting millis to nanos,
+    // but if millis is that large then we will end up limiting to
+    // MAX_SECS anyway, so just do that here.
+    if (millis / MILLIUNITS > MAX_SECS) {
+      millis = jlong(MAX_SECS) * MILLIUNITS;
+    }
+    to_abstime(&abst, millis * (NANOUNITS / MILLIUNITS), false);
+
+    int ret = OS_TIMEOUT;
+    int status = pthread_cond_timedwait(&_cond, &_mutex, &abst);
+    assert_status(status == 0 || status == ETIMEDOUT,
+                  status, "cond_timedwait");
+    if (status == 0) {
+      ret = OS_OK;
+    }
+    return ret;
+  } else {
+    int status = pthread_cond_wait(&_cond, &_mutex);
+    assert_status(status == 0, status, "cond_wait");
+    return OS_OK;
+  }
+}
+
+void os::PlatformMonitor::notify() {
+  int status = pthread_cond_signal(&_cond);
+  assert_status(status == 0, status, "cond_signal");
+}
+
+void os::PlatformMonitor::notify_all() {
+  int status = pthread_cond_broadcast(&_cond);
+  assert_status(status == 0, status, "cond_broadcast");
+}
+
+#endif // INCLUDE_ZGC
+
 
 #endif // !SOLARIS

--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -219,6 +219,25 @@ class PlatformParker : public CHeapObj<mtSynchronizer> {
   PlatformParker();
 };
 
+#if INCLUDE_ZGC
+// Platform specific implementation that underpins VM Monitor/Mutex class
+class PlatformMonitor : public CHeapObj<mtInternal> {
+ private:
+  pthread_mutex_t _mutex; // Native mutex for locking
+  pthread_cond_t  _cond;  // Native condition variable for blocking
+
+ public:
+  PlatformMonitor();
+  ~PlatformMonitor();
+  void lock();
+  void unlock();
+  bool try_lock();
+  int wait(jlong millis);
+  void notify();
+  void notify_all();
+};
+#endif // INCLUDE_ZGC
+
 #endif // !SOLARIS
 
 #endif // OS_POSIX_VM_OS_POSIX_HPP

--- a/src/hotspot/share/gc/z/zLock.hpp
+++ b/src/hotspot/share/gc/z/zLock.hpp
@@ -57,14 +57,9 @@ public:
 
 class ZConditionLock {
 private:
-  // See JDK-8210832
-  pthread_mutex_t _mutex; // Native mutex for locking
-  pthread_cond_t  _cond;  // Native condition variable for blocking
+  os::PlatformMonitor _lock;
 
 public:
-  ZConditionLock();
-  ~ZConditionLock();
-
   void lock();
   bool try_lock();
   void unlock();

--- a/src/hotspot/share/gc/z/zLock.inline.hpp
+++ b/src/hotspot/share/gc/z/zLock.inline.hpp
@@ -26,9 +26,9 @@
 
 #include "gc/z/zLock.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/os.inline.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
-#include "runtime/os.inline.hpp"
 
 inline ZLock::ZLock() {
   pthread_mutex_init(&_lock, NULL);
@@ -85,62 +85,28 @@ inline bool ZReentrantLock::is_owned() const {
   return owner == thread;
 }
 
-inline ZConditionLock::ZConditionLock() {
-  pthread_cond_init(&_cond, NULL);
-  pthread_mutex_init(&_mutex, NULL);
-}
-
-inline ZConditionLock::~ZConditionLock() {
-  pthread_cond_destroy(&_cond);
-  pthread_mutex_destroy(&_mutex);
-}
-
 inline void ZConditionLock::lock() {
-  pthread_mutex_lock(&_mutex);
+  _lock.lock();
 }
 
 inline bool ZConditionLock::try_lock() {
-  return pthread_mutex_trylock(&_mutex) == 0;
+  return _lock.try_lock();
 }
 
 inline void ZConditionLock::unlock() {
-  pthread_mutex_unlock(&_mutex);
+  _lock.unlock();
 }
 
 inline bool ZConditionLock::wait(uint64_t millis) {
-  if (millis > 0) {
-    jlong timeout = millis * (NANOUNITS / MILLIUNITS);
-
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME, &now);
-
-    // Calculate a new absolute time that is "timeout" nanoseconds from "now".
-    struct timespec abstime;
-    jlong seconds = timeout / NANOUNITS;
-    abstime.tv_sec = now.tv_sec + seconds;
-
-    timeout %= NANOUNITS; // remaining nanos
-    long nanos = now.tv_nsec + timeout;
-    if (nanos >= NANOUNITS) { // overflow
-      abstime.tv_sec += 1;
-      nanos -= NANOUNITS;
-    }
-    abstime.tv_nsec = nanos;
-
-    int status = pthread_cond_timedwait(&_cond, &_mutex, &abstime);
-    return status == 0;
-  } else {
-    pthread_cond_wait(&_cond, &_mutex);
-    return true;
-  }
+  return _lock.wait(millis) == OS_OK;
 }
 
 inline void ZConditionLock::notify() {
-  pthread_cond_signal(&_cond);
+  _lock.notify();
 }
 
 inline void ZConditionLock::notify_all() {
-  pthread_cond_broadcast(&_cond);
+  _lock.notify_all();
 }
 
 template <typename T>


### PR DESCRIPTION
Summary: Compilation error due to clock_gettime().
  Backport os::PlatformMonitor, the original Monitor implementation for
  ZConditionLock. Relavent JDK patches:
  * 8210832: https://github.com/openjdk/jdk/commit/c94cdddbdd
  * 8246265: https://github.com/openjdk/jdk/commit/cd16b568ce

Test Plan: gc/z/

Reviewed-by: linade, weixlu

Issue: https://github.com/alibaba/dragonwell11/pull/115