### PR TITLE
[GC] Add option ZMediumObjectUpperBound for ZGC

### DIFF
--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -46,6 +46,9 @@ void ZHeuristics::set_medium_page_size() {
     ZPageSizeMedium             = size;
     ZPageSizeMediumShift        = log2_intptr(ZPageSizeMedium);
     ZObjectSizeLimitMedium      = ZPageSizeMedium / 8;
+    if (!FLAG_IS_DEFAULT(ZMediumObjectUpperBound)) {
+      ZObjectSizeLimitMedium    = ZMediumObjectUpperBound;
+    }
     ZObjectAlignmentMediumShift = (int)ZPageSizeMediumShift - 13;
     ZObjectAlignmentMedium      = 1 << ZObjectAlignmentMediumShift;
   }

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -78,6 +78,11 @@
           "Percentage of total heap size reserved for relocation.")         \
           range(0,100)                                                      \
                                                                             \
+  experimental(uintx, ZMediumObjectUpperBound, 4*M,                         \
+          "Upper bound of the object size in ZGC medium page"               \
+          "(can be any even integer between 4M and 32M)")                   \
+          range(4*M, 32*M)                                                  \
+                                                                            \
   diagnostic(uint, ZStatisticsInterval, 10,                                 \
           "Time between statistics print outs (in seconds)")                \
           range(1, (uint)-1)                                                \


### PR DESCRIPTION
Summary: Adjust the upper bound of the object size in medium pages.

Reviewed-by: mmyxym, weixlu

Test Plan: hotspot_gc and tier1 with ZGC

Issue: https://github.com/alibaba/dragonwell11/pull/116