### PR TITLE
[GC] Add ZRelocationReserve to reserve more space for ZGC relocation

### DIFF
--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -57,6 +57,10 @@ size_t ZHeuristics::max_reserve() {
   // memory during relocation.
   const uint nworkers = MAX2(ParallelGCThreads, ConcGCThreads);
   const size_t reserve = (nworkers * ZPageSizeSmall) + ZPageSizeMedium;
+  if (!FLAG_IS_DEFAULT(ZRelocationReservePercent)) {
+    const size_t reserve2 = MaxHeapSize * ZRelocationReservePercent / 100;
+    return MIN2(MaxHeapSize, MAX2(reserve, reserve2));
+  }
   return MIN2(MaxHeapSize, reserve);
 }
 

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -74,6 +74,10 @@
           "Percentage of heap usage for ZGC high usage rule")               \
           range(0.0, 100.0)                                                 \
                                                                             \
+  experimental(uintx, ZRelocationReservePercent, 0,                         \
+          "Percentage of total heap size reserved for relocation.")         \
+          range(0,100)                                                      \
+                                                                            \
   diagnostic(uint, ZStatisticsInterval, 10,                                 \
           "Time between statistics print outs (in seconds)")                \
           range(1, (uint)-1)                                                \


### PR DESCRIPTION
Summary: Reserve more space for ZGC relocation to avoid OOM.

Test Plan: gc/z/

Reviewed-by: mmyxym, weixlu

Issue: https://github.com/alibaba/dragonwell11/pull/117