### PR TITLE
[Misc] rename ClassResolveCache to ResolvedClassCache

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -235,7 +235,7 @@ public class ObjectInputStream
 {
     /**
      * enable fast serialization:
-     * 1. Create a {@link ClassResolveCache} to reduce calls to {@link Class#forName(String)}
+     * 1. Create a {@link ResolvedClassCache} to reduce calls to {@link Class#forName(String)}
      * 2. Cache {@link #latestUserDefinedLoader()}: The loader can be safely cached inside the
      *    ObjectInputStream class, once custom {@link #readObject()} methods are invoked, the cache
      *    will be invalid.
@@ -771,7 +771,7 @@ public class ObjectInputStream
             if (latestUserDefinedLoaderCache == null) {
                 latestUserDefinedLoaderCache = latestUserDefinedLoader();
             }
-            return ClassResolveCache.forName(name, latestUserDefinedLoaderCache,
+            return ResolvedClassCache.forName(name, latestUserDefinedLoaderCache,
                     (className, loader) -> {
                         try {
                             return Class.forName(className, false, loader);

--- a/src/java.base/share/classes/java/io/ResolvedClassCache.java
+++ b/src/java.base/share/classes/java/io/ResolvedClassCache.java
@@ -30,9 +30,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 
 /**
- * This class holds the class resolve cache for FAST_SERIALIZATION feature.
+ * This class holds the resolved class cache for FAST_SERIALIZATION feature.
  */
-final class ClassResolveCache {
+final class ResolvedClassCache {
     private final static Map<String, List<Entry>> nameToClasses = new ConcurrentHashMap<>();
 
     /**


### PR DESCRIPTION
Summary:
Give a more meaningful name to the class cache in fast serialization
feature.

Reviewed-by: D-D-H, joeyleeeeeee97

Test Plan: run ObjectInputStream jtregs

Issue: #118