### PR TITLE
[GC] Backport gc.testlibrary.Allocation.blackHole for ZGC JFR tests

### DIFF
--- a/test/hotspot/jtreg/gc/testlibrary/Allocation.java
+++ b/test/hotspot/jtreg/gc/testlibrary/Allocation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.testlibrary;
+
+public class Allocation {
+    public static volatile Object obj;
+
+    /**
+     * This code assigns the object to a "public static volatile" variable. The
+     * compiler does not seem capable of optimizing through this (yet). Any object
+     * allocated and sent to this method ought not to be optimized away.
+     *
+     * @param obj The allocation of this object will not be optimized away.
+     */
+
+    public static void blackHole(Object obj) {
+        Allocation.obj = obj;
+        Allocation.obj = null;
+    }
+}

--- a/test/hotspot/jtreg/gc/z/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/z/TestSmallHeap.java
@@ -27,12 +27,12 @@ package gc.z;
  * @test TestSmallHeap
  * @requires vm.gc.Z & !vm.graal.enabled
  * @summary Test ZGC with small heaps
- * @library /test/lib
+ * @library / /test/lib
  * @run main/othervm gc.z.TestSmallHeap 8M 16M 32M 64M 128M 256M 512M 1024M
  */
 
 import jdk.test.lib.process.ProcessTools;
-import java.lang.ref.Reference;
+import static gc.testlibrary.Allocation.blackHole;
 
 public class TestSmallHeap {
     public static class Test {
@@ -44,7 +44,7 @@ public class TestSmallHeap {
             // all allocation paths (small/medium/large) are tested.
             for (int length = 16; length <= maxCapacity / 16; length *= 2) {
                 System.out.println("Allocating " + length + " bytes");
-                Reference.reachabilityFence(new byte[length]);
+                blackHole(new byte[length]);
             }
 
             System.out.println("Success");


### PR DESCRIPTION
Summary: ZGC JFR tests are using gc.testlibrary.Allocation.blackHole
  instead of java.lang.ref.Reference.reachabilityFence (JDK-8235250).
  JDK-8235250: https://github.com/openjdk/jdk/commit/c023983c7f

Reviewed-by: linade, weixlu

Test Plan: jdk/jdk/jfr/event/gc/detailed/, hotspot/jtreg/gc/z/

Issue: https://github.com/alibaba/dragonwell11/pull/126