### PR TITLE
[GC] Fix an assertion failure on ZGC class unloading

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSet.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.cpp
@@ -42,7 +42,7 @@ class ZBarrierSetC2;
 
 static BarrierSetNMethod* make_barrier_set_nmethod() {
   // NMethod barriers are only used when class unloading is enabled
-  if (!ClassUnloading || ZUnloadClassesFrequency == 0) {
+  if (!ClassUnloading) {
     return NULL;
   }
 

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -144,7 +144,7 @@ public:
   ZMarkRootsTask(ZMark* mark) :
       ZTask("ZMarkRootsTask"),
       _mark(mark),
-      _roots() {}
+      _roots(true /* marking */) {}
 
   virtual void work() {
     ZMarkRootsIteratorClosure cl;

--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -156,7 +156,8 @@ void ZRootsIteratorClosure::do_thread(Thread* thread) {
   thread->oops_do(this, ZHeap::heap()->should_unload_class() ? &code_cl : NULL);
 }
 
-ZRootsIterator::ZRootsIterator() :
+ZRootsIterator::ZRootsIterator(bool marking) :
+    _marking(marking),
     _jni_handles_iter(JNIHandles::global_handles()),
     _universe(this),
     _object_synchronizer(this),
@@ -232,7 +233,11 @@ void ZRootsIterator::do_system_dictionary(ZRootsIteratorClosure* cl) {
 void ZRootsIterator::do_class_loader_data_graph(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsClassLoaderDataGraph);
   CLDToOopClosure cld_cl(cl);
-  ClassLoaderDataGraph::cld_do(&cld_cl);
+  if (_marking) {
+    ClassLoaderDataGraph::always_strong_cld_do(&cld_cl);
+  } else {
+    ClassLoaderDataGraph::cld_do(&cld_cl);
+  }
 }
 
 void ZRootsIterator::do_threads(ZRootsIteratorClosure* cl) {

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -84,6 +84,7 @@ public:
 
 class ZRootsIterator {
 private:
+  bool _marking;
   ZOopStorageIterator _jni_handles_iter;
 
   void do_universe(ZRootsIteratorClosure* cl);
@@ -109,7 +110,7 @@ private:
   ZParallelOopsDo<ZRootsIterator, &ZRootsIterator::do_code_cache>              _code_cache;
 
 public:
-  ZRootsIterator();
+  ZRootsIterator(bool marking = false);
   ~ZRootsIterator();
 
   void oops_do(ZRootsIteratorClosure* cl, bool visit_jvmti_weak_export = false);

--- a/src/hotspot/share/gc/z/zUnload.cpp
+++ b/src/hotspot/share/gc/z/zUnload.cpp
@@ -80,7 +80,7 @@ public:
 ZUnload::ZUnload(ZWorkers* workers) :
     _workers(workers) {
 
-  if (!ZHeap::heap()->should_unload_class()) {
+  if (!ClassUnloading) {
     return;
   }
 


### PR DESCRIPTION
(1) Fix incorrect `do_class_loader_data_graph` by applying `always_strong_cld_do`

(2) forcely trigger unloading if cause == system_gc

(3) Debug build failed when ZGC is unloading classes. `ZHeap::heap()` is NULL at this point.