### PR TITLE
fix: #143  wsl2 ubuntu18.04  libiconv_open error

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -112,7 +112,7 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
 
   BASIC_JDKLIB_LIBS=""
   if test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
-    BASIC_JDKLIB_LIBS="-ljava -ljvm"
+    BASIC_JDKLIB_LIBS="-ljava -ljvm -liconv"
   fi
 
   # Math library


### PR DESCRIPTION
fix error #143  undefined reference to `libiconv_open’