### PR TITLE
[GC] Add ZMemoryTagging for ZGC

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zArguments_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zArguments_aarch64.cpp
@@ -31,4 +31,10 @@ void ZArguments::initialize_platform() {
   // Disable class unloading - we don't support concurrent class unloading yet.
   FLAG_SET_DEFAULT(ClassUnloading, false);
   FLAG_SET_DEFAULT(ClassUnloadingWithConcurrentMark, false);
+
+  if(ZMemoryTagging && ZVerifyViews && FLAG_IS_CMDLINE(ZMemoryTagging) && FLAG_IS_CMDLINE(ZVerifyViews)) {
+    warning("ZMemoryTagging is incompatible with ZVerifyViews"
+            "; ignoring ZMemoryTagging flag." );
+    ZMemoryTagging = false;
+  }
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4101,7 +4101,7 @@ void MacroAssembler::movoop(Register dst, jobject obj, bool immediate) {
     oop_index = oop_recorder()->find_index(obj);
   }
   RelocationHolder rspec = oop_Relocation::spec(oop_index);
-  if (! immediate) {
+  if (ZGC_ONLY(ZMemoryTagging || )! immediate) {
     address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby aligned address
     ldr_constant(dst, Address(dummy, rspec));
   } else

--- a/src/hotspot/cpu/x86/gc/z/zArguments_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zArguments_x86.cpp
@@ -25,5 +25,6 @@
 #include "gc/z/zArguments.hpp"
 
 void ZArguments::initialize_platform() {
-  // Does nothing
+  // x86 doesn't support MT.
+  FLAG_SET_DEFAULT(ZMemoryTagging, false);
 }

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -141,7 +141,11 @@ inline ZPhysicalMemory& ZPage::physical_memory() {
 
 inline uint8_t ZPage::numa_id() {
   if (_numa_id == (uint8_t)-1) {
-    _numa_id = (uint8_t)ZNUMA::memory_id(ZAddress::good(start()));
+    if (ZMemoryTagging) {
+      _numa_id = (uint8_t) ZNUMA::memory_id(start());
+    } else {
+      _numa_id = (uint8_t)ZNUMA::memory_id(ZAddress::good(start()));
+    }
   }
 
   return _numa_id;

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -45,8 +45,11 @@ ZVirtualMemoryManager::ZVirtualMemoryManager() :
   }
 
   // Make the complete address view free
-  _manager.free(0, ZAddressOffsetMax);
-
+  if (ZMemoryTagging) {
+    _manager.free(ZAddressSpaceStart, ZAddressOffsetMax - ZAddressSpaceStart);
+  } else {
+    _manager.free(0, ZAddressOffsetMax);
+  }
   // Register address space with native memory tracker
   nmt_reserve(ZAddressSpaceStart, ZAddressSpaceSize);
 

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -87,6 +87,9 @@
           "Unload the classes every Nth ZGC cycle."                         \
           "Set to zero to disable class unloading.")                        \
                                                                             \
+  product(bool, ZMemoryTagging, false,                                      \
+          "Enable AArch64 TBI feature for memory tagging.")                 \
+                                                                            \
   diagnostic(uint, ZStatisticsInterval, 10,                                 \
           "Time between statistics print outs (in seconds)")                \
           range(1, (uint)-1)                                                \


### PR DESCRIPTION
Summary: Enable AArch64 memory tagging feature for colour pointer.

Reviewed-by: albert.th

Test Plan: tier1 with ZGC

Issue: https://github.com/alibaba/dragonwell11/pull/176