### PR TITLE
[GC] Disarm all nmethods if the ZGC cycle does not unload classes

### DIFF
--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -144,7 +144,7 @@ public:
   ZMarkRootsTask(ZMark* mark) :
       ZTask("ZMarkRootsTask"),
       _mark(mark),
-      _roots(true /* marking */) {}
+      _roots() {}
 
   virtual void work() {
     ZMarkRootsIteratorClosure cl;

--- a/src/hotspot/share/gc/z/zNMethodTable.cpp
+++ b/src/hotspot/share/gc/z/zNMethodTable.cpp
@@ -546,21 +546,22 @@ void ZNMethodTable::entry_oops_do(ZNMethodTableEntry entry, OopClosure* cl) {
   }
 }
 
-class ZNMethodTableEntryToOopsDo : public ZNMethodTableEntryClosure {
+class ZNMethodTableEntryToOopsDoAndDisarm : public ZNMethodTableEntryClosure {
 private:
   OopClosure* _cl;
 
 public:
-  ZNMethodTableEntryToOopsDo(OopClosure* cl) :
+  ZNMethodTableEntryToOopsDoAndDisarm(OopClosure* cl) :
       _cl(cl) {}
 
   void do_nmethod_entry(ZNMethodTableEntry entry) {
     ZNMethodTable::entry_oops_do(entry, _cl);
+    ZNMethodTable::disarm_nmethod(entry.method());
   }
 };
 
-void ZNMethodTable::oops_do(OopClosure* cl) {
-  ZNMethodTableEntryToOopsDo entry_cl(cl);
+void ZNMethodTable::oops_do_and_disarm(OopClosure* cl) {
+  ZNMethodTableEntryToOopsDoAndDisarm entry_cl(cl);
   nmethod_entries_do(&entry_cl);
 }
 

--- a/src/hotspot/share/gc/z/zNMethodTable.hpp
+++ b/src/hotspot/share/gc/z/zNMethodTable.hpp
@@ -76,7 +76,7 @@ public:
 
   static ZReentrantLock* lock_for_nmethod(nmethod* nm);
 
-  static void oops_do(OopClosure* cl);
+  static void oops_do_and_disarm(OopClosure* cl);
 
   static void entry_oops_do(ZNMethodTableEntry entry, OopClosure* cl);
 

--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -156,8 +156,7 @@ void ZRootsIteratorClosure::do_thread(Thread* thread) {
   thread->oops_do(this, ZHeap::heap()->should_unload_class() ? &code_cl : NULL);
 }
 
-ZRootsIterator::ZRootsIterator(bool marking) :
-    _marking(marking),
+ZRootsIterator::ZRootsIterator() :
     _jni_handles_iter(JNIHandles::global_handles()),
     _universe(this),
     _object_synchronizer(this),
@@ -233,7 +232,7 @@ void ZRootsIterator::do_system_dictionary(ZRootsIteratorClosure* cl) {
 void ZRootsIterator::do_class_loader_data_graph(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsClassLoaderDataGraph);
   CLDToOopClosure cld_cl(cl);
-  if (_marking) {
+  if (ZHeap::heap()->should_unload_class()) {
     ClassLoaderDataGraph::always_strong_cld_do(&cld_cl);
   } else {
     ClassLoaderDataGraph::cld_do(&cld_cl);
@@ -248,7 +247,7 @@ void ZRootsIterator::do_threads(ZRootsIteratorClosure* cl) {
 
 void ZRootsIterator::do_code_cache(ZRootsIteratorClosure* cl) {
   ZStatTimer timer(ZSubPhasePauseRootsCodeCache);
-  ZNMethodTable::oops_do(cl);
+  ZNMethodTable::oops_do_and_disarm(cl);
 }
 
 void ZRootsIterator::oops_do(ZRootsIteratorClosure* cl, bool visit_jvmti_weak_export) {

--- a/src/hotspot/share/gc/z/zRootsIterator.hpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.hpp
@@ -84,7 +84,6 @@ public:
 
 class ZRootsIterator {
 private:
-  bool _marking;
   ZOopStorageIterator _jni_handles_iter;
 
   void do_universe(ZRootsIteratorClosure* cl);
@@ -110,7 +109,7 @@ private:
   ZParallelOopsDo<ZRootsIterator, &ZRootsIterator::do_code_cache>              _code_cache;
 
 public:
-  ZRootsIterator(bool marking = false);
+  ZRootsIterator();
   ~ZRootsIterator();
 
   void oops_do(ZRootsIteratorClosure* cl, bool visit_jvmti_weak_export = false);

--- a/test/hotspot/jtreg/gc/z/unloading/TestUnloadFrequency.java
+++ b/test/hotspot/jtreg/gc/z/unloading/TestUnloadFrequency.java
@@ -1,0 +1,121 @@
+
+package gc.z.unloading;
+
+/*
+ * @test TestUnloadFrequency
+ * @requires vm.gc.Z & !vm.graal.enabled
+ * @library / /test/lib /runtime/testlibrary
+ * @summary Unload Frequency Bug
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:+UseZGC -XX:ZUnloadClassesFrequency=2 -Xlog:gc* -Xms128m -Xmx128m -XX:TieredStopAtLevel=1 -XX:-Inline
+ *      gc.z.unloading.TestUnloadFrequency
+ */
+
+import com.sun.management.GarbageCollectionNotificationInfo;
+import jdk.test.lib.Asserts;
+import sun.hotspot.WhiteBox;
+
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static gc.testlibrary.Allocation.blackHole;
+
+class Recorder {
+    public Object fld;
+}
+
+class ZUnloadingTestCase {
+    public static Object foo() {
+        return bar(Boolean.TRUE); // immediate value
+    }
+
+    public static Object bar(Boolean b) {
+        Recorder obj = new Recorder();
+        obj.fld = b; // (critical) store an immediate value from foo()
+        return obj;
+    }
+}
+
+/*
+In this test, we check if the nmethod entry barrier of foo() (complied into a nmethod) is armed or disarmed correctly during ZGC cycles,
+especially the cycles that do not unload classes.
+
+With -XX:ZUnloadClassesFrequency=2, odd ZGC cycles do unloading, while even ZGC cycles do not unload classes.
+
+We let foo() be called once during the concurrent mark phase of each odd GC cycle (GC(1), GC(3), ...).
+If calling foo() during GC(1) triggers its nmethod entry barrier correctly, the disarmed value of foo() should be set to Marked0.
+Assume that foo()'s nmethod entry barrier was not disarmed during GC(2), we will find the disarmed value of foo() is Marked0 during GC(3),
+which means calling foo() during GC(3) will not trigger its nmethod entry barrier. Therefore, the immediate values in foo() that are lastly
+updated by GC(2) may be used mistakenly during GC(3).
+
+ZGC checks each store in the interpreter mode (ZBarrierSetAssembler::store_at()). Therefore, we let foo() passes an immediate value to bar()
+(not compiled), then bar() stores the value to an arbitrary object.
+*/
+public class TestUnloadFrequency {
+    public static WhiteBox wb = WhiteBox.getWhiteBox();
+
+    private static AtomicLong cycleId = new AtomicLong(-1);
+    private static boolean neverPausedInCycle = false;
+
+    public static void main(String[] args) throws Exception {
+        // Setup
+        compileOnlyFooWithoutBar();
+        callFooInOddCycles(); // try to call foo() during concurrent mark of odd ZGC cycles
+
+        // Trigger at least 20 ZGC cycles, because foo() is not always called during concurrent mark in time
+        while (cycleId.get() < 20) {
+            blackHole(new byte[4096]);
+        }
+    }
+
+    private static void compileOnlyFooWithoutBar() throws Exception {
+        Method methodFoo = ZUnloadingTestCase.class.getDeclaredMethod("foo");
+        Method methodBar = ZUnloadingTestCase.class.getDeclaredMethod("bar", Boolean.class);
+
+        wb.makeMethodNotCompilable(methodBar);
+        while (!wb.isMethodCompiled(methodFoo)) {
+            ZUnloadingTestCase.foo();
+        }
+
+        Asserts.assertTrue(wb.isMethodCompiled(methodFoo), "foo() should be compiled.");
+        Asserts.assertFalse(wb.isMethodCompiled(methodBar), "bar() should not be compiled.");
+    }
+
+    private static void callFooInOddCycles() {
+        final NotificationListener listener = (Notification notification, Object ignored) -> {
+            final var type = notification.getType();
+            if (!type.equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
+                return;
+            }
+
+            final var data = (CompositeData)notification.getUserData();
+            final var info = GarbageCollectionNotificationInfo.from(data);
+            final var name = info.getGcName();
+
+            if (name.equals("ZGC Cycles")) {
+                final var id = info.getGcInfo().getId();
+                cycleId.set(id);
+                neverPausedInCycle = true;
+            } else if (name.equals("ZGC Pauses")) {
+                if ((cycleId.get() % 2 == 1) && neverPausedInCycle) {
+                    ZUnloadingTestCase.foo();
+                    System.out.println("try to call foo() during GC(" + cycleId + ") Concurrent Mark");
+                    neverPausedInCycle = false;
+                }
+            }
+        };
+
+        for (final var collector : ManagementFactory.getGarbageCollectorMXBeans()) {
+            final NotificationEmitter emitter = (NotificationEmitter)collector;
+            emitter.addNotificationListener(listener, null, null);
+        }
+    }
+}


### PR DESCRIPTION
Summary: "Verify oop store failed" if an immediate value of a nmethod is accessed,
  because the corresponding nmethod entry barrier is not disarmed properly.

Reviewed-by: mmyxym, weixlu

Test Plan: jtreg/gc/z/unloading/TestUnloading.java

Issue: https://github.com/alibaba/dragonwell11/issues/177