### PR TITLE
[GC] MXBean should report the pause time of class unloading

### DIFF
--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -199,6 +199,7 @@ public:
 
   virtual bool do_operation() {
     ZStatTimer timer(ZPhasePauseUnloadClass);
+    ZServiceabilityPauseTracer tracer;
     ZHeap::heap()->unload_class();
     return true;
   }


### PR DESCRIPTION
Summary: So far GC MXBean fails to report the pause time of ZGC class unloading. We report the pause time in this patch.

Reviewed-by: mmyxym, albert.th

Test Plan: jtreg/gc/z/

Issue: https://github.com/alibaba/dragonwell11/issues/180