### PR TITLE
[JFR] Fix JFR related test cases caused by merging 11.0.13

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -328,6 +328,8 @@ static void write_primitive(JfrCheckpointWriter* writer, KlassPtr type_array_kla
   writer->write(mark_symbol(primitive_symbol(type_array_klass), false));
   writer->write(package_id(Universe::boolArrayKlassObj(), false));
   writer->write(get_primitive_flags());
+  // we use 0 as object size for primitive types since there is no instance concept for primitive types.
+  writer->write((s4)0);
 }
 
 static int primitives_count = 9;


### PR DESCRIPTION
Summary: use 0 as size value for primitive types

Test Plan: all JFR related test cases

Reviewed-by: leveretconey, kelthuzadx

Issue: https://github.com/alibaba/dragonwell11/pull/188