### PR TITLE
[JFR] Fix object profiling stacktrace problem on aarch64 platform

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -248,7 +248,7 @@ JVM_ENTRY_NO_ENV(jlong, jfr_class_id(JNIEnv* env, jclass jvm, jclass jc))
 JVM_END
 
 JVM_ENTRY_NO_ENV(jlong, jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip))
-  return JfrStackTraceRepository::record(thread, skip, WALK_BY_DEFAULT);
+  return JfrStackTraceRepository::record(thread, skip);
 JVM_END
 
 JVM_ENTRY_NO_ENV(void, jfr_log(JNIEnv* env, jobject jvm, jint tag_set, jint level, jstring message))

--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -125,7 +125,7 @@ class RecordStackTrace {
   RecordStackTrace(JavaThread* jt) : _jt(jt),
     _enabled(JfrEventSetting::has_stacktrace(EventOldObjectSample::eventId)) {
     if (_enabled) {
-      JfrStackTraceRepository::record_for_leak_profiler(jt, 0, WALK_BY_DEFAULT);
+      JfrStackTraceRepository::record_for_leak_profiler(jt, 0);
     }
   }
   ~RecordStackTrace() {

--- a/src/hotspot/share/jfr/recorder/jfrEventSetting.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrEventSetting.cpp
@@ -55,14 +55,6 @@ void JfrEventSetting::set_enabled(jlong id, bool enabled) {
   setting(event_id).enabled = enabled;
 }
 
-StackWalkMode JfrEventSetting::stack_walk_mode(JfrEventId event_id) {
-  if (event_id == JfrOptoArrayObjectAllocationEvent ||
-      event_id == JfrOptoInstanceObjectAllocationEvent) {
-    return WALK_BY_CURRENT_FRAME;
-  }
-  return WALK_BY_DEFAULT;
-}
-
 #ifdef ASSERT
 bool JfrEventSetting::bounds_check_event(jlong id) {
   if ((unsigned)id < NUM_RESERVED_EVENTS || (unsigned)id >= MaxJfrEventId) {

--- a/src/hotspot/share/jfr/recorder/jfrEventSetting.hpp
+++ b/src/hotspot/share/jfr/recorder/jfrEventSetting.hpp
@@ -47,7 +47,6 @@ class JfrEventSetting : AllStatic {
   static jlong threshold(JfrEventId event_id);
   static bool set_cutoff(jlong event_id, jlong cutoff_ticks);
   static jlong cutoff(JfrEventId event_id);
-  static StackWalkMode stack_walk_mode(JfrEventId event_id);
   DEBUG_ONLY(static bool bounds_check_event(jlong id);)
 };
 

--- a/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
@@ -177,7 +177,7 @@ class JfrEvent {
         if (tl->has_cached_stack_trace()) {
           writer.write(tl->cached_stack_trace_id());
         } else {
-          writer.write(JfrStackTraceRepository::record(event_thread, 0, JfrEventSetting::stack_walk_mode(T::eventId)));
+          writer.write(JfrStackTraceRepository::record(event_thread, 0));
         }
       } else {
         writer.write<traceid>(0);

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -229,43 +229,14 @@ void JfrStackTrace::resolve_linenos() const {
   _lineno = true;
 }
 
-bool JfrStackTrace::record_safe(JavaThread* thread, int skip, StackWalkMode mode) {
+bool JfrStackTrace::record_safe(JavaThread* thread, int skip) {
   assert(thread == Thread::current(), "Thread stack needs to be walkable");
-
-  bool success = false;
-  switch(mode) {
-    case WALK_BY_DEFAULT:
-      {
-        vframeStream vfs(thread);
-        success = fill_in(vfs, skip, mode);
-        break;
-      }
-    case WALK_BY_CURRENT_FRAME:
-      {
-        vframeStream vfs(thread, os::current_frame());
-        success = fill_in(vfs, skip, mode);
-        break;
-      }
-    default:
-      ShouldNotReachHere();
-  }
-  return success;
-}
-
-bool JfrStackTrace::fill_in(vframeStream& vfs, int skip, StackWalkMode mode) {
+  vframeStream vfs(thread);
   u4 count = 0;
   _reached_root = true;
-  // Indicates whether the top frame is visited in this frames iteration.
-  // Top frame bci may be invalid and fill_in() will fix the top frame bci in a conservative way.
-  bool top_frame_visited = false;
   for (int i = 0; i < skip; i++) {
     if (vfs.at_end()) {
       break;
-    }
-    // The top frame is in skip list.
-    // Mark top_frame_visited to avoid unnecessary top frame bci fixing.
-    if (!top_frame_visited) {
-      top_frame_visited = true;
     }
     vfs.next();
   }
@@ -282,26 +253,9 @@ bool JfrStackTrace::fill_in(vframeStream& vfs, int skip, StackWalkMode mode) {
     int bci = 0;
     if (method->is_native()) {
       type = JfrStackFrame::FRAME_NATIVE;
-      // The top frame is in native.
-      // Mark top_frame_visited to avoid unnecessary top frame bci fixing.
-      if (!top_frame_visited) {
-        top_frame_visited = true;
-      }
     }
     else {
       bci = vfs.bci();
-      // Hit the top frame and fix bci here.
-      if (!top_frame_visited) {
-        if (mode == WALK_BY_CURRENT_FRAME) {
-          // Only fix opto fast path allocation.
-          // All fast path allocations do not have cached event id.
-          if (!vfs.thread_ref()->jfr_thread_local()->has_cached_event_id()) {
-            assert(vfs.thread_ref()->jfr_thread_local()->has_cached_top_frame_bci(), "Invariant");
-            bci = vfs.thread_ref()->jfr_thread_local()->cached_top_frame_bci();
-          }
-        }
-        top_frame_visited = true;
-      }
     }
     // Can we determine if it's inlined?
     _hash = (_hash * 31) + mid;

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.hpp
@@ -35,15 +35,6 @@ class JfrChunkWriter;
 class Method;
 class vframeStream;
 
-enum StackWalkMode {
-  // walk stack by vframeStream vfs(thread).
-  WALK_BY_DEFAULT = 0,
-  // walk stack by vframeStream vfs(thread, os::current_frame()).
-  // It is only used in JIT runtime leaf call. In JIT runtime leaf call,
-  // last_java_sp is not maintained and WALK_BY_DEFAULT can not walk stack.
-  WALK_BY_CURRENT_FRAME
-};
-
 class JfrStackFrame {
   friend class ObjectSampleCheckpoint;
  private:
@@ -91,7 +82,7 @@ class JfrStackTrace : public JfrCHeapObj {
   mutable bool _lineno;
   mutable bool _written;
 
-  bool fill_in(vframeStream& vfs, int skip, StackWalkMode mode);
+  bool fill_in(vframeStream& vfs, int skip);
 
   const JfrStackTrace* next() const { return _next; }
 
@@ -107,7 +98,7 @@ class JfrStackTrace : public JfrCHeapObj {
   void resolve_linenos() const;
 
   bool record_thread(JavaThread& thread, frame& frame);
-  bool record_safe(JavaThread* thread, int skip, StackWalkMode mode);
+  bool record_safe(JavaThread* thread, int skip);
 
   bool have_lineno() const { return _lineno; }
   bool full_stacktrace() const { return _reached_root; }

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -61,16 +61,16 @@ class JfrStackTraceRepository : public JfrCHeapObj {
   size_t write(JfrChunkWriter& cw, bool clear);
 
   static const JfrStackTrace* lookup_for_leak_profiler(unsigned int hash, traceid id);
-  static void record_for_leak_profiler(JavaThread* thread, int skip, StackWalkMode mode);
+  static void record_for_leak_profiler(JavaThread* thread, int skip);
   static void clear_leak_profiler();
 
   traceid add_trace(const JfrStackTrace& stacktrace);
   static traceid add(JfrStackTraceRepository& repo, const JfrStackTrace& stacktrace);
   static traceid add(const JfrStackTrace& stacktrace);
-  traceid record_for(JavaThread* thread, int skip, StackWalkMode mode, JfrStackFrame* frames, u4 max_frames);
+  traceid record_for(JavaThread* thread, int skip, JfrStackFrame* frames, u4 max_frames);
 
  public:
-  static traceid record(Thread* thread, int skip, StackWalkMode mode);
+  static traceid record(Thread* thread, int skip);
 };
 
 #endif // SHARE_JFR_RECORDER_STACKTRACE_JFRSTACKTRACEREPOSITORY_HPP

--- a/src/hotspot/share/jfr/support/jfrFlush.cpp
+++ b/src/hotspot/share/jfr/support/jfrFlush.cpp
@@ -70,12 +70,12 @@ void jfr_conditional_flush(JfrEventId id, size_t size, Thread* t) {
   }
 }
 
-bool jfr_save_stacktrace(Thread* t, StackWalkMode mode) {
+bool jfr_save_stacktrace(Thread* t) {
   JfrThreadLocal* const tl = t->jfr_thread_local();
   if (tl->has_cached_stack_trace()) {
     return false; // no ownership
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0, mode));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0));
   return true;
 }
 

--- a/src/hotspot/share/jfr/support/jfrFlush.hpp
+++ b/src/hotspot/share/jfr/support/jfrFlush.hpp
@@ -45,7 +45,7 @@ class JfrFlush : public StackObj {
 void jfr_conditional_flush(JfrEventId id, size_t size, Thread* t);
 bool jfr_is_event_enabled(JfrEventId id);
 bool jfr_has_stacktrace_enabled(JfrEventId id);
-bool jfr_save_stacktrace(Thread* t, StackWalkMode mode);
+bool jfr_save_stacktrace(Thread* t);
 void jfr_clear_stacktrace(Thread* t);
 
 template <typename Event>
@@ -68,7 +68,7 @@ class JfrConditionalFlushWithStacktrace : public JfrConditionalFlush<Event> {
  public:
   JfrConditionalFlushWithStacktrace(Thread* t) : JfrConditionalFlush<Event>(t), _t(t), _owner(false) {
     if (this->_enabled && Event::has_stacktrace() && jfr_has_stacktrace_enabled(Event::eventId)) {
-      _owner = jfr_save_stacktrace(t, JfrEventSetting::stack_walk_mode(Event::eventId));
+      _owner = jfr_save_stacktrace(t);
     }
   }
   ~JfrConditionalFlushWithStacktrace() {

--- a/src/hotspot/share/jfr/support/jfrStackTraceMark.cpp
+++ b/src/hotspot/share/jfr/support/jfrStackTraceMark.cpp
@@ -36,7 +36,7 @@ JfrStackTraceMark::JfrStackTraceMark() : _t(Thread::current()), _previous_id(0),
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(Thread::current(), 0, WALK_BY_DEFAULT));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(Thread::current(), 0));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previous_hash(0) {
@@ -45,7 +45,7 @@ JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previ
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0, WALK_BY_DEFAULT));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_id(0), _previous_hash(0) {
@@ -56,8 +56,7 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_i
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    StackWalkMode mode = JfrEventSetting::stack_walk_mode(eventId);
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0, mode));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0));
   }
 }
 
@@ -69,8 +68,7 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId, Thread* t) : _t(NULL), 
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    StackWalkMode mode = JfrEventSetting::stack_walk_mode(eventId);
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0, mode));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0));
   }
 }
 

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -56,7 +56,6 @@ JfrThreadLocal::JfrThreadLocal() :
   _stackdepth(0),
   _entering_suspend_flag(0),
   _dead(false),
-  _cached_top_frame_bci(max_jint),
   _alloc_count(0),
   _alloc_count_until_sample(1),
   _cached_event_id(MaxJfrEventId) {

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -53,18 +53,6 @@ class JfrThreadLocal {
   volatile jint _entering_suspend_flag;
   bool _dead;
   traceid _parent_trace_id;
-  // Jfr callstack collection relies on vframeStream.
-  // But the bci of top frame can not be determined by vframeStream in some scenarios.
-  // For example, in the opto CallLeafNode runtime call of
-  // OptoRuntime::jfr_fast_object_alloc_C, the top frame bci
-  // returned by vframeStream is always invalid. This is largely due to the oopmap that
-  // is not correctly granted ( refer to PhaseMacroExpand::expand_allocate_common to get more details ).
-  // The opto fast path object allocation tracing occurs in the opto CallLeafNode,
-  // which has been broken by invalid top frame bci.
-  // To fix this, we get the top frame bci in opto compilation phase
-  // and pass it as parameter to runtime call. Our implementation will replace the invalid top
-  // frame bci with cached_top_frame_bci.
-  jint _cached_top_frame_bci;
   jlong _alloc_count;
   jlong _alloc_count_until_sample;
   // This field is used to help to distinguish the object allocation request source
@@ -216,22 +204,6 @@ class JfrThreadLocal {
 
   void set_wallclock_time(jlong wallclock_time) {
     _wallclock_time = wallclock_time;
-  }
-
-  void set_cached_top_frame_bci(jint bci) {
-    _cached_top_frame_bci = bci;
-  }
-
-  bool has_cached_top_frame_bci() const {
-    return _cached_top_frame_bci != max_jint;
-  }
-
-  jint cached_top_frame_bci() const {
-    return _cached_top_frame_bci;
-  }
-
-  void clear_cached_top_frame_bci() {
-    _cached_top_frame_bci = max_jint;
   }
 
   jlong alloc_count() const {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1771,18 +1771,6 @@ void PhaseMacroExpand::expand_allocate_common(
   // This completes all paths into the result merge point
 }
 
-static jint bottom_java_frame_bci(JVMState* state) {
-  assert(state != NULL, "Invariant");
-
-  JVMState* last = NULL;
-  JVMState* current = state;
-  while (current != NULL) {
-    last = current;
-    current = current->caller();
-  }
-  return last->bci();
-}
-
 //
 // Pseudo code:
 //
@@ -1810,74 +1798,59 @@ void PhaseMacroExpand::jfr_sample_fast_object_allocation(
   Node* alloc_sample_enabled_mem = fast_oop_rawmem;
   Node* alloc_sample_disabled_ctrl = transform_later(new IfFalseNode(alloc_sample_enabled_if));
   Node* alloc_sample_disabled_mem = fast_oop_rawmem;
-  Node* alloc_sample_enabled_region = transform_later(new RegionNode(3));
-  Node* alloc_sample_enabled_region_phi_mem = transform_later(new PhiNode(alloc_sample_enabled_region, Type::MEMORY, TypeRawPtr::BOTTOM));
-  enum { enabled_idx = 1,  disabled_idx = 2 };
 
-  // if _enabled then
-  {
-    const int alloc_count_offset = in_bytes(TRACE_THREAD_ALLOC_COUNT_OFFSET);
-    Node* alloc_count = make_load(alloc_sample_enabled_ctrl, alloc_sample_enabled_mem, tls, alloc_count_offset, TypeLong::LONG, T_LONG);
-    Node* alloc_count_new = transform_later(new AddLNode(alloc_count, longcon(1)));
-    alloc_sample_enabled_mem = make_store(alloc_sample_enabled_ctrl, alloc_sample_enabled_mem, tls, alloc_count_offset, alloc_count_new, T_LONG);
-    const int alloc_count_until_sample_offset = in_bytes(TRACE_THREAD_ALLOC_COUNT_UNTIL_SAMPLE_OFFSET);
-    Node* alloc_count_until_sample = make_load(alloc_sample_enabled_ctrl, alloc_sample_enabled_mem, tls, alloc_count_until_sample_offset, TypeLong::LONG, T_LONG);
-    Node* alloc_count_until_sample_cmp = transform_later(new CmpLNode(alloc_count_until_sample, alloc_count_new));
-    Node* alloc_sample_hit_bool = transform_later(new BoolNode(alloc_count_until_sample_cmp, BoolTest::eq));
-    IfNode* alloc_sample_hit_if = (IfNode*)transform_later(new IfNode(alloc_sample_enabled_ctrl, alloc_sample_hit_bool, PROB_MIN, COUNT_UNKNOWN));
-    Node* alloc_sample_hit_ctrl = transform_later(new IfTrueNode(alloc_sample_hit_if));
-    Node* alloc_sample_hit_mem = alloc_sample_enabled_mem;
-    Node* alloc_sample_miss_ctrl = transform_later(new IfFalseNode(alloc_sample_hit_if));
-    Node* alloc_sample_miss_mem = alloc_sample_enabled_mem;
-    Node* alloc_sample_hit_region = transform_later(new RegionNode(3));
-    Node* alloc_sample_hit_region_phi_mem = transform_later(new PhiNode(alloc_sample_hit_region, Type::MEMORY, TypeRawPtr::BOTTOM));
+  enum { disabled_idx = 1, hit_idx = 2, miss_idx = 3 };
+  Node* result_region = transform_later(new RegionNode(4));
+  Node* result_phi_mem = transform_later(new PhiNode(result_region, Type::MEMORY, TypeRawPtr::BOTTOM));
 
-    // if sample_hit then
-    {
-      CallLeafNode *call = new CallLeafNode(OptoRuntime::jfr_fast_object_alloc_Type(),
-                                            CAST_FROM_FN_PTR(address, OptoRuntime::jfr_fast_object_alloc_C),
-                                            "jfr_fast_object_alloc_C",
-                                            TypeRawPtr::BOTTOM);
-      call->init_req(TypeFunc::Parms+0, fast_oop);
-      call->init_req(TypeFunc::Parms+1, intcon(bottom_java_frame_bci(alloc->jvms())));
-      call->init_req(TypeFunc::Parms+2, tls);
-      call->init_req(TypeFunc::Control, alloc_sample_hit_ctrl);
-      call->init_req(TypeFunc::I_O    , top());
-      call->init_req(TypeFunc::Memory , alloc_sample_hit_mem);
-      call->init_req(TypeFunc::ReturnAdr, alloc->in(TypeFunc::ReturnAdr));
-      call->init_req(TypeFunc::FramePtr, alloc->in(TypeFunc::FramePtr));
-      transform_later(call);
-      alloc_sample_hit_ctrl = new ProjNode(call,TypeFunc::Control);
-      transform_later(alloc_sample_hit_ctrl);
-      alloc_sample_hit_mem = new ProjNode(call,TypeFunc::Memory);
-      transform_later(alloc_sample_hit_mem);
+  const int alloc_count_offset = in_bytes(TRACE_THREAD_ALLOC_COUNT_OFFSET);
+  Node* alloc_count = make_load(alloc_sample_enabled_ctrl, alloc_sample_enabled_mem, tls, alloc_count_offset, TypeLong::LONG, T_LONG);
+  Node* alloc_count_new = transform_later(new AddLNode(alloc_count, longcon(1)));
+  alloc_sample_enabled_mem = make_store(alloc_sample_enabled_ctrl, alloc_sample_enabled_mem, tls, alloc_count_offset, alloc_count_new, T_LONG);
+  const int alloc_count_until_sample_offset = in_bytes(TRACE_THREAD_ALLOC_COUNT_UNTIL_SAMPLE_OFFSET);
+  Node* alloc_count_until_sample = make_load(alloc_sample_enabled_ctrl, alloc_sample_enabled_mem, tls, alloc_count_until_sample_offset, TypeLong::LONG, T_LONG);
+  Node* alloc_count_until_sample_cmp = transform_later(new CmpLNode(alloc_count_until_sample, alloc_count_new));
+  Node* alloc_sample_hit_bool = transform_later(new BoolNode(alloc_count_until_sample_cmp, BoolTest::eq));
+  IfNode* alloc_sample_hit_if = (IfNode*)transform_later(new IfNode(alloc_sample_enabled_ctrl, alloc_sample_hit_bool, PROB_MIN, COUNT_UNKNOWN));
+  Node* alloc_sample_hit_ctrl = transform_later(new IfTrueNode(alloc_sample_hit_if));
+  Node* alloc_sample_hit_mem = alloc_sample_enabled_mem;
+  Node* alloc_sample_miss_ctrl = transform_later(new IfFalseNode(alloc_sample_hit_if));
+  Node* alloc_sample_miss_mem = alloc_sample_enabled_mem;
 
-      alloc_sample_hit_region->init_req(enabled_idx, alloc_sample_hit_ctrl);
-      alloc_sample_hit_region_phi_mem->init_req(enabled_idx, alloc_sample_hit_mem);
-    }
+  // if sample_hit then
+  address addr = OptoRuntime::jfr_fast_object_alloc_Java();
+  CallStaticJavaNode *call = new CallStaticJavaNode(OptoRuntime::jfr_fast_object_alloc_Type(),
+                                                        addr,
+                                                        OptoRuntime::stub_name(addr),
+                                                        alloc->jvms()->bci(),
+                                                        TypeRawPtr::BOTTOM);
 
-    {
-      alloc_sample_hit_region->init_req(disabled_idx, alloc_sample_miss_ctrl);
-      alloc_sample_hit_region_phi_mem->init_req(disabled_idx, alloc_sample_miss_mem);
-    }
+  call->init_req(TypeFunc::Control, alloc_sample_hit_ctrl);
+  call->init_req(TypeFunc::I_O    , alloc->in(TypeFunc::I_O));
+  call->init_req(TypeFunc::Memory , alloc_sample_hit_mem);
+  call->init_req(TypeFunc::ReturnAdr, alloc->in(TypeFunc::ReturnAdr));
+  call->init_req(TypeFunc::FramePtr, alloc->in(TypeFunc::FramePtr));
 
-    {
-      alloc_sample_enabled_ctrl = alloc_sample_hit_region;
-      alloc_sample_enabled_mem = alloc_sample_hit_region_phi_mem;
-    }
-    alloc_sample_enabled_region->init_req(enabled_idx, alloc_sample_enabled_ctrl);
-    alloc_sample_enabled_region_phi_mem->init_req(enabled_idx, alloc_sample_enabled_mem);
-  }
+  call->init_req(TypeFunc::Parms+0, fast_oop);
 
-  {
-    alloc_sample_enabled_region->init_req(disabled_idx, alloc_sample_disabled_ctrl);
-    alloc_sample_enabled_region_phi_mem->init_req(disabled_idx, alloc_sample_disabled_mem);
-  }
+  copy_call_debug_info(alloc, call);
+  transform_later(call);
 
-  {
-    fast_oop_ctrl = alloc_sample_enabled_region;
-    fast_oop_rawmem = alloc_sample_enabled_region_phi_mem;
-  }
+  alloc_sample_hit_ctrl = new ProjNode(call,TypeFunc::Control);
+  transform_later(alloc_sample_hit_ctrl);
+  alloc_sample_hit_mem = new ProjNode(call,TypeFunc::Memory);
+  transform_later(alloc_sample_hit_mem);
+
+  // fill region
+  result_region->init_req(hit_idx, alloc_sample_hit_ctrl);
+  result_phi_mem->init_req(hit_idx, alloc_sample_hit_mem);
+  result_region->init_req(disabled_idx, alloc_sample_disabled_ctrl);
+  result_phi_mem->init_req(disabled_idx, alloc_sample_disabled_mem);
+  result_region->init_req(miss_idx, alloc_sample_miss_ctrl);
+  result_phi_mem->init_req(miss_idx, alloc_sample_miss_mem);
+
+  fast_oop_ctrl = result_region;
+  fast_oop_rawmem = result_phi_mem;
 }
 
 

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -150,6 +150,7 @@ class OptoRuntime : public AllStatic {
 
   static address _slow_arraycopy_Java;
   static address _register_finalizer_Java;
+  static address _jfr_fast_object_alloc_Java;
 
   //
   // Implementation of runtime methods
@@ -181,7 +182,7 @@ public:
   static void monitor_notifyAll_C(oopDesc* obj, JavaThread* thread);
 
   // JFR support
-  static void jfr_fast_object_alloc_C(oopDesc* obj, jint bci, JavaThread* thread);
+  static void jfr_fast_object_alloc_C(oopDesc* obj, JavaThread* thread);
 private:
 
   // Implicit exception support
@@ -232,6 +233,7 @@ private:
 
   static address slow_arraycopy_Java()                   { return _slow_arraycopy_Java; }
   static address register_finalizer_Java()               { return _register_finalizer_Java; }
+  static address jfr_fast_object_alloc_Java()            { return _jfr_fast_object_alloc_Java; }
 
   static ExceptionBlob*    exception_blob()                      { return _exception_blob; }
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2973,7 +2973,7 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
       EventThreadStart::is_stacktrace_enabled()) {
     JfrThreadLocal* tl = native_thread->jfr_thread_local();
     // skip Thread.start() and Thread.start0()
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread, 2, WALK_BY_DEFAULT));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread, 2));
   }
 #endif
 

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -335,7 +335,6 @@ class vframeStream : public vframeStreamCommon {
   vframeStream(JavaThread* thread, bool stop_at_java_call_stub = false);
 
   Thread *& thread_ref()    {
-    assert(EnableCoroutine, "EnableCoroutine is off");
     return (Thread *&)_thread;
   }
 

--- a/test/jdk/jdk/jfr/event/objectsprofiling/TestOptoObjectAllocationsSampling.java
+++ b/test/jdk/jdk/jfr/event/objectsprofiling/TestOptoObjectAllocationsSampling.java
@@ -170,14 +170,14 @@ public class TestOptoObjectAllocationsSampling {
                     Asserts.assertTrue(!clazz.isArray());
                     Asserts.assertTrue(objectSize > 0);
                     Asserts.assertTrue(topFrame.getLineNumber() > 0);
-                    Asserts.assertTrue(topFrame.getBytecodeIndex() > 0);
+                    Asserts.assertEquals(7, topFrame.getBytecodeIndex());
                     countOfInstanceObject++;
                 } else if (className.equals(arrayObjectClassName)) {
                     Asserts.assertTrue(clazz.isArray());
                     Asserts.assertTrue(objectSize == RECORDED_ARRAY_CLASS_OBJECT_SIZE_MAGIC_CODE);
                     countOfArrayObject++;
                     Asserts.assertTrue(topFrame.getLineNumber() > 0);
-                    Asserts.assertTrue(topFrame.getBytecodeIndex() > 0);
+                    Asserts.assertEquals(1, topFrame.getBytecodeIndex());
                 }
             }
             System.out.format("Total Event Count: %d, EventOptoInstanceObjectAllocaiton Count: %d, EventOptoArrayObjectAllocation Count: %d\n", events.size(), countOfInstanceObject, countOfArrayObject);


### PR DESCRIPTION
Hi,
Please help review this patch that fixes the stack trace problem of object profiling on the aarch64 platform.

The root cause of this problem is that the stack layout of aarch64 is different from x86_64 so that we cannot use vframeStream(thread, os::current_frame()) to get the java call stack traces.

This fix uses CallStaticJavaNode to invoke the jfr_fast_object_alloc_C so that the _last_Java_pc is set properly by opto stub.

Issue: https://github.com/alibaba/dragonwell11/issues/189
Denghui