### PR TITLE
[Misc] fix unstable wisp tests

### DIFF
--- a/test/jdk/com/alibaba/wisp/TestWispCounter.java
+++ b/test/jdk/com/alibaba/wisp/TestWispCounter.java
@@ -68,11 +68,10 @@ public class TestWispCounter {
     }
 
     private static ServerSocket ss;
-    private static final int PORT = 23000;
     private static final int BUFFER_SIZE = 1024;
 
     private static void startNetServer() throws IOException {
-        ss = new ServerSocket(PORT);
+        ss = new ServerSocket();
         Thread t = new Thread(() -> {
             try {
                 while (true) {
@@ -92,7 +91,7 @@ public class TestWispCounter {
 
     private static void doNetIO() {
         try {
-            Socket so = new Socket("localhost", PORT);
+            Socket so = new Socket("localhost", ss.getLocalPort());
             OutputStream os = so.getOutputStream();
             os.write(new byte[BUFFER_SIZE]);
             os.flush();

--- a/test/jdk/com/alibaba/wisp/TestWispDetailCounter.java
+++ b/test/jdk/com/alibaba/wisp/TestWispDetailCounter.java
@@ -86,11 +86,10 @@ public class TestWispDetailCounter {
     }
 
     private static ServerSocket ss;
-    private static final int PORT = 23000;
     private static final int BUFFER_SIZE = 1024;
 
     private static void startNetServer() throws IOException {
-        ss = new ServerSocket(PORT);
+        ss = new ServerSocket();
         Thread t = new Thread(() -> {
             try {
                 while (true) {
@@ -110,7 +109,7 @@ public class TestWispDetailCounter {
 
     private static void doNetIO() {
         try {
-            Socket so = new Socket("localhost", PORT);
+            Socket so = new Socket("localhost", ss.getLocalPort());
             OutputStream os = so.getOutputStream();
             os.write(new byte[BUFFER_SIZE]);
             os.flush();

--- a/test/jdk/com/alibaba/wisp/TestWispMonitorData.java
+++ b/test/jdk/com/alibaba/wisp/TestWispMonitorData.java
@@ -81,11 +81,10 @@ public class TestWispMonitorData {
     }
 
     private static ServerSocket ss;
-    private static final int PORT = 23000;
     private static final int BUFFER_SIZE = 1024;
 
     private static void startNetServer() throws IOException {
-        ss = new ServerSocket(PORT);
+        ss = new ServerSocket();
         Thread t = new Thread(() -> {
             try {
                 while (true) {
@@ -105,7 +104,7 @@ public class TestWispMonitorData {
 
     private static void doNetIO() {
         try {
-            Socket so = new Socket("localhost", PORT);
+            Socket so = new Socket("localhost", ss.getLocalPort());
             OutputStream os = so.getOutputStream();
             os.write(new byte[BUFFER_SIZE]);
             os.flush();

--- a/test/jdk/com/alibaba/wisp/io/TestCreateFdOnDemand.java
+++ b/test/jdk/com/alibaba/wisp/io/TestCreateFdOnDemand.java
@@ -7,9 +7,13 @@
 */
 
 import java.io.File;
+import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import com.alibaba.wisp.engine.WispEngine;
 
@@ -31,7 +35,7 @@ public class TestCreateFdOnDemand {
         ds.close();
 
 
-        final int nfd0 = countFd();
+        final long nfd0 = countFd();
         so = new Socket();
         assertEQ(countFd(), nfd0);
         sso = new ServerSocket();
@@ -54,8 +58,15 @@ public class TestCreateFdOnDemand {
         assertEQ(countFd(), nfd0);
     }
 
-    private static int countFd() {
-        File f = new File("/proc/self/fd");
-        return f.list().length;
+    private static long countFd() throws IOException {
+        File f = new File("/proc/self/fd");;
+        return  Arrays.stream(Objects.requireNonNull(f.listFiles())).filter(file -> {
+            try {
+                return file.getCanonicalPath().contains("/proc/");
+            } catch (IOException e) {
+                //invalid path
+                return false;
+            }
+        }).count();
     }
 }


### PR DESCRIPTION
Summary: Use unbound port to avoid confliction.

Reviewed-by: yuleil, kelthuzadx

Test Plan: jtreg wisp

Issue: https://github.com/alibaba/dragonwell11/issues/192