### PR TITLE
[RISCV] support paired memory instruction in CSky

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2190,6 +2190,29 @@ enum Nf {
 #undef INSN
 #undef patch_VLdSt
 
+// CSky specific Instruction
+// load into 2 registers, store 2 registers
+#define INSN(NAME, op, funct3, funct5)                                                       \
+  void NAME(Register Rd1, Register Rd2, Register Rs, const int32_t offset) {                 \
+    guarantee(offset >= 0 && offset <= 3, "offset is invalid.");                          \
+    unsigned insn = 0;                                                                             \
+    int32_t val = offset & 0x3;                                                              \
+    patch((address)&insn, 6,  0,  op);                                                             \
+    patch_reg((address)&insn, 7,  Rd1);                                                            \
+    patch((address)&insn, 14, 12, funct3);                                                         \
+    patch_reg((address)&insn, 15, Rs);                                                             \
+    patch_reg((address)&insn, 20, Rd2);                                                            \
+    patch((address)&insn, 26, 25, val);                                                            \
+    patch((address)&insn, 31, 27, funct5);                                                         \
+    emit(insn);                                                                                    \
+  }
+  INSN(ldd,  0b0001011, 0b100, 0b11111);
+  INSN(lwd,  0b0001011, 0b100, 0b11100);
+  INSN(lwud, 0b0001011, 0b100, 0b11110);
+  INSN(sdd,  0b0001011, 0b101, 0b11111);
+  INSN(swd,  0b0001011, 0b101, 0b11100);
+#undef INSN
+
   void bgt(Register Rs, Register Rt, const address &dest);
   void ble(Register Rs, Register Rt, const address &dest);
   void bgtu(Register Rs, Register Rt, const address &dest);

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -109,5 +109,6 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Extend fence.i to fence.i + fence.")                         \
   product(bool, AvoidUnalignedAccesses, true,                           \
           "Avoid generating unaligned memory accesses")                 \
+  product(bool, UseCSky, false, "Use CSky specific instructions")       \
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1198,13 +1198,14 @@ bool MacroAssembler::ldst_can_merge(Register rt,
   }
 
   // alignment check
-  if ( (low_offset % (prev_size_in_bytes*2)) != 0 ) {
+  if ((low_offset % (prev_size_in_bytes*2)) != 0) {
     return false;
   }
 
-  if ( is_unsigned && !prev_ldst->is_unsigned_load()) {
+  if (!is_store && prev_size_in_bytes == 4 && is_unsigned != prev_ldst->is_unsigned_load()) {
     return false;
   }
+
   return true;
 }
 
@@ -1245,11 +1246,11 @@ void MacroAssembler::merge_ldst(Register rt,
       ldd(rt_low, rt_high, rt_base, offset >> 4);
     } else {
       if (is_unsigned) {
-        BLOCK_COMMENT("merged load pair: lwd");
-        lwd(rt_low, rt_high, rt_base, offset >> 3);
-      } else {
         BLOCK_COMMENT("merged load pair: lwud");
         lwud(rt_low, rt_high, rt_base, offset >> 3);
+      } else {
+        BLOCK_COMMENT("merged load pair: lwd");
+        lwd(rt_low, rt_high, rt_base, offset >> 3);
       }
     }
   } else {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -351,6 +351,32 @@ class MacroAssembler: public Assembler {
     return ((predecessor & 0x3) << 2) | (successor & 0x3);
   }
 
+  // CSky specific mem pair instructions
+  using Assembler::ld;
+  using Assembler::sd;
+  using Assembler::lw;
+  using Assembler::lwu;
+  using Assembler::sw;
+
+  // Check whether two loads/stores can be merged into ldp/stp.
+  bool ldst_can_merge(Register rt, const Address &adr,
+                      size_t cur_size_in_bytes, bool is_store, bool is_unsigned) const;
+
+  // Merge current load/store with previous load/store into ldp/stp.
+  void merge_ldst(Register rx, const Address &adr,
+                  size_t cur_size_in_bytes, bool is_store, bool is_unsigned);
+
+  // Try to merge two loads/stores into ldp/stp. If success, returns true else false.
+  bool try_merge_ldst(Register rt, const Address &adr,
+                      size_t cur_size_in_bytes, bool is_store, bool is_unsigned);
+
+  void ld(Register Rx, const Address &adr);
+  void sd(Register Rw, const Address &adr);
+  void lw(Register Rx, const Address &adr);
+  void lwu(Register Rx, const Address &adr);
+  void sw(Register Rw, const Address &adr);
+  // end of CSky specific instructions
+
   // prints msg, dumps registers and stops execution
   void stop(const char* msg);
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -39,6 +39,43 @@
 #include "c1/c1_Runtime1.hpp"
 #endif
 
+Register NativeInstruction::extract_rs1(address instr) {
+  assert_cond(instr != NULL);
+  return as_Register(Assembler::extract(((unsigned*)instr)[0], 19, 15));
+}
+
+Register NativeInstruction::extract_rs2(address instr) {
+  assert_cond(instr != NULL);
+  return as_Register(Assembler::extract(((unsigned*)instr)[0], 24, 20));
+}
+
+Register NativeInstruction::extract_rd(address instr) {
+  assert_cond(instr != NULL);
+  return as_Register(Assembler::extract(((unsigned*)instr)[0], 11, 7));
+}
+
+uint32_t NativeInstruction::extract_opcode(address instr) {
+  assert_cond(instr != NULL);
+  return Assembler::extract(((unsigned*)instr)[0], 6, 0);
+}
+
+uint32_t NativeInstruction::extract_funct3(address instr) {
+  assert_cond(instr != NULL);
+  return Assembler::extract(((unsigned*)instr)[0], 14, 12);
+}
+
+/*
+uint32_t NativeInstruction::extract_funct7(address instr) {
+  assert_cond(instr != NULL);
+  return Assembler::extract(((unsigned*)instr)[0], 31, 25);
+}
+*/
+
+int32_t NativeInstruction::sextract_funct7(address instr) {
+  assert_cond(instr != NULL);
+  return Assembler::sextract(((unsigned*)instr)[0], 31, 25);
+}
+
 bool NativeInstruction::is_pc_relative_at(address instr) {
   // auipc + jalr
   // auipc + addi

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -960,13 +960,16 @@ int MachCallRuntimeNode::ret_addr_offset() {
   //   la(t0, RuntimeAddress(addr))   ->  lui + addi + slli + addi + slli + addi
   //   addi(sp, sp, -2 * wordSize)    ->  addi
   //   sd(zr, Address(sp))            ->  sd
-  //   sd(t1, Address(sp, wordSize))  ->  sd
+  //   sd(t1, Address(sp, wordSize))  ->  sd   -> sdd in CSky
   //   jalr(t0)                       ->  jalr
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb != NULL) {
     return 1 * NativeInstruction::instruction_size;
   } else {
-    return 12 * NativeInstruction::instruction_size;
+    if (UseCSky)
+      return 11 * NativeInstruction::instruction_size;
+    else
+      return 12 * NativeInstruction::instruction_size;
   }
 }
 


### PR DESCRIPTION
Summary:
add UseCSky option to enable csky instructions
merge ld/st into paired memory instructions

Test Plan: SPECjbb2005

Reviewed-by: zhengxiaolinX

Issue: https://github.com/alibaba/dragonwell11/issues/216

CR: https://github.com/alibaba/dragonwell11/pull/217