### PR TITLE
[JFR] Unexpected behavior when enable Opto related allocation event by JCMD when -XX:FlightRecorderOptions=sampleobjectallocations=true is disabled

### DIFF
--- a/test/jdk/jdk/jfr/event/objectsprofiling/TestOptionIsDisabled.java
+++ b/test/jdk/jdk/jfr/event/objectsprofiling/TestOptionIsDisabled.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jfr.event.objectsprofiling;
+
+import java.io.File;
+
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/*
+ * @test TestOptionIsDisabled
+ * @library /test/lib
+ *
+ * @compile -g TestOptionIsDisabled.java
+ *
+ * @run main/othervm jfr.event.objectsprofiling.TestOptionIsDisabled
+ * @run main/othervm -XX:FlightRecorderOptions=sampleobjectallocations=false jfr.event.objectsprofiling.TestOptionIsDisabled
+ */
+public class TestOptionIsDisabled {
+    private static final String DIR = System.getProperty("test.src", ".");
+    private static final File SETTINGS = new File(DIR, "testsettings.jfc");
+
+    public static void main(String... args) throws Exception {
+        String name = "TestOptionIsDisabled";
+        OutputAnalyzer output = new PidJcmdExecutor().execute(
+                "JFR.start" +
+                " name=" + name +
+                " settings=" + SETTINGS.getCanonicalPath());
+        output.shouldContain("Can't enable OptoInstanceObjectAllocation/OptoArrayObjectAllocation Event if -XX:FlightRecorderOptions=sampleobjectallocations=true is not set");
+    }
+}

--- a/test/jdk/jdk/jfr/event/objectsprofiling/testsettings.jfc
+++ b/test/jdk/jdk/jfr/event/objectsprofiling/testsettings.jfc
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright (c) 2022 Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+-->
+<configuration version="2.0" label="Settings" description="Object Profiling" provider="Dragonwell">
+    <event name="jdk.OptoInstanceObjectAllocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event name="jdk.OptoArrayObjectAllocation">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+</configuration>


### PR DESCRIPTION
Summary: Should use the logic like DCmdStart#hasJDKEvents to determine
if an event is enabled or not

Test Plan: jdk/jfr/event/objectsprofiling/TestOptionIsDisabled.java

Reviewed-by: yanglong1010, kelthuzadx

Issue: https://github.com/alibaba/dragonwell11/issues/237