### PR TITLE
[GC] Restore option ZUnmapBadViews

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -101,6 +101,12 @@ void ZArguments::initialize() {
   // we need fixup_partial_loads
   DEBUG_ONLY(FLAG_SET_DEFAULT(VerifyStack, false));
 
+  // Support ZUnmapBadView in order to be compatible with Java 11
+  if (FLAG_IS_DEFAULT(ZVerifyViews) && ZUnmapBadViews) {
+    log_warning(gc)("ZUnmapBadViews is deprecated. Will use ZVerifyViews instead.");
+    FLAG_SET_DEFAULT(ZVerifyViews, true);
+  }
+
   // Initialize platform specific arguments
   initialize_platform();
 }

--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -91,6 +91,9 @@
           "Time between statistics print outs (in seconds)")                \
           range(1, (uint)-1)                                                \
                                                                             \
+  diagnostic(bool, ZUnmapBadViews, false,                                   \
+          "Unmap bad (inactive) heap views")                                \
+                                                                            \
   diagnostic(bool, ZVerifyViews, false,                                     \
           "Verify heap view accesses")                                      \
                                                                             \

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -33,6 +33,12 @@
  *                   -XX:+ZVerifyViews -XX:ZCollectionInterval=1
  *                   -XX:-CreateCoredumpOnCrash
  *                   -XX:CompileCommand=dontinline,*::mergeImpl* compiler.gcbarriers.UnsafeIntrinsicsTest
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UseZGC
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+ZUnmapBadViews -XX:ZCollectionInterval=1
+ *                   -XX:-CreateCoredumpOnCrash
+ *                   -XX:CompileCommand=dontinline,*::mergeImpl* compiler.gcbarriers.UnsafeIntrinsicsTest
  */
 
  /*


### PR DESCRIPTION
Summary: ZUnmapBadViews has been removed in
  https://github.com/alibaba/dragonwell11/commit/39f759e977 .
  In order to be compatible with Java 11, ZUnmapBadViews must be
  supported. To achieve compatibility, This patch makes ZUnmapBadViews
  indentical with ZVerifyViews.

Reviewed-by: mmyxym, linade

Test Plan: test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java

Issue: https://github.com/alibaba/dragonwell11/pull/240