### PR TITLE
[Misc]: fix testcase TestSoftMaxHeapSizeFlag.java run error

### DIFF
--- a/test/hotspot/jtreg/gc/z/TestSoftMaxHeapSizeFlag.java
+++ b/test/hotspot/jtreg/gc/z/TestSoftMaxHeapSizeFlag.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package gc.arguments;
+package gc.z;
 
 /*
  * @test TestSoftMaxHeapSizeFlag
@@ -29,7 +29,7 @@ package gc.arguments;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm gc.arguments.TestSoftMaxHeapSizeFlag
+ * @run main/othervm gc.z.TestSoftMaxHeapSizeFlag
  */
 
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
Reviewed-by: tanghaoth90,joeyleeeeeee97

Summary: fix testcase TestSoftMaxHeapSizeFlag.java run error for error package name

Test Plan: test/hotspot/jtreg/gc/z/TestSoftMaxHeapSizeFlag.java

Issue: #223

Signed-off-by: sendaoYan yansendao.ysd@alibaba-inc.com