### PR TITLE
[Misc] Supports white spaces in vendor-version-string

### DIFF
--- a/make/autoconf/jdk-version.m4
+++ b/make/autoconf/jdk-version.m4
@@ -505,7 +505,8 @@ AC_DEFUN_ONCE([JDKVER_SETUP_JDK_VERSION_NUMBERS],
       [Set vendor version string @<:@not specified@:>@])])
   if test "x$with_vendor_version_string" = xyes; then
     AC_MSG_ERROR([--with-vendor-version-string must have a value])
-  elif [ ! [[ $with_vendor_version_string =~ ^[[:graph:]]*$ ]] ]; then
+  elif [ ! [[ $with_vendor_version_string =~ ^[[:print:]]*$ ]] ]; then
+    # Dragonwell supports white spaces in vendor-version-string
     AC_MSG_ERROR([--with--vendor-version-string contains non-graphical characters: $with_vendor_version_string])
   else
     VENDOR_VERSION_STRING="$with_vendor_version_string"


### PR DESCRIPTION
Summary: supports white spaces in vendor-version-string

Test Plan: CICD

Reviewed-by: lei.yul, sendaoYan

Issue: https://github.com/alibaba/dragonwell11/issues/246