### PR TITLE
[Wisp] Fix missing oops_do for WispThread

### DIFF
--- a/src/hotspot/share/runtime/coroutine.cpp
+++ b/src/hotspot/share/runtime/coroutine.cpp
@@ -991,6 +991,10 @@ const char* WispThread::print_blocking_status(int status) {
   }
 }
 
+void WispThread::oops_do(OopClosure *f, CodeBlobClosure *cf) {
+  f->do_oop((oop*) &_threadObj);
+}
+
 void Coroutine::after_safepoint(JavaThread* thread) {
   assert(Thread::current() == thread, "sanity check");
 

--- a/src/hotspot/share/runtime/coroutine.hpp
+++ b/src/hotspot/share/runtime/coroutine.hpp
@@ -469,6 +469,9 @@ public:
     return thread->is_Wisp_thread() ? (WispThread*) thread : 
       ((JavaThread*) thread)->current_coroutine()->wisp_thread();
   }
+
+  // Memory operations
+  void oops_do(OopClosure* f, CodeBlobClosure* cf);
 };
 
 // we supported coroutine stealing for following native calls:

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3005,6 +3005,9 @@ void JavaThread::oops_do(OopClosure* f, CodeBlobClosure* cf) {
     Coroutine* current = _coroutine_list;
     do {
       current->oops_do(f, cf);
+      if (UseWispMonitor) {
+        current->wisp_thread()->oops_do(f, cf);
+      }
       current = current->next();
     } while (current != _coroutine_list);
   }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -937,6 +937,7 @@ class JavaThread: public Thread {
   friend class VMStructs;
   friend class JVMCIVMStructs;
   friend class WhiteBox;
+  friend class WispThread;
  private:
   JavaThread*    _next;                          // The next thread in the Threads list
   bool           _on_thread_list;                // Is set when this JavaThread is added to the Threads list


### PR DESCRIPTION
Summary: Wisp unfortunately missed doing do_oop() for WispThread, which is corresponded to a Coroutine data structure. We shall add it.

Test Plan: all wisp tests

Reviewed-by: yuleil, sanhong

Issue: #263