### PR TITLE
[Wisp] Blocking io support for SocketChannel and Pipe

### DIFF
--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -26,12 +26,14 @@ package com.alibaba.wisp.engine;
 import jdk.internal.misc.JavaLangAccess;
 import jdk.internal.misc.SharedSecrets;
 import jdk.internal.misc.WispEngineAccess;
+import sun.nio.ch.Net;
 
 import java.dyn.Coroutine;
 import java.dyn.CoroutineExitException;
 import java.dyn.CoroutineSupport;
 import java.io.IOException;
 import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -362,6 +364,37 @@ public class WispEngine extends AbstractExecutorService {
                 } else {
                     return task.status == WispTask.Status.CACHED ? Thread.State.TERMINATED : Thread.State.RUNNABLE;
                 }
+            }
+
+            @Override
+            public int poll(SelectableChannel channel, int interestOps, long millsTimeOut) throws IOException {
+                assert interestOps == Net.POLLIN || interestOps == Net.POLLCONN || interestOps == Net.POLLOUT;
+                WispTask task = WispCarrier.current().getCurrentTask();
+                if (millsTimeOut > 0) {
+                    task.carrier.addTimer(System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(millsTimeOut),
+                            TimeOut.Action.JDK_UNPARK);
+                }
+                try {
+                    task.carrier.registerEvent(channel, translateToSelectionKey(interestOps));
+                    park(-1);
+                    return millsTimeOut > 0 && task.timeOut.expired() ? 0 : 1;
+                } finally {
+                    if (millsTimeOut > 0) {
+                        task.carrier.cancelTimer();
+                    }
+                    unregisterEvent();
+                }
+            }
+
+            private int translateToSelectionKey(int event) {
+                if (Net.POLLIN == event) {
+                    return SelectionKey.OP_READ;
+                } else if (Net.POLLCONN == event) {
+                    return SelectionKey.OP_CONNECT;
+                } else if (Net.POLLOUT == event) {
+                    return SelectionKey.OP_WRITE;
+                }
+                return 0;
             }
         });
     }

--- a/src/java.base/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -178,7 +178,12 @@ public class WispEngine {
             public Thread.State getState(Thread thread) {
                 return null;
             }
-            });
+
+            @Override
+            public int poll(SelectableChannel channel, int interestOps, long timeout) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+        });
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/misc/WispEngineAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/WispEngineAccess.java
@@ -63,4 +63,13 @@ public interface WispEngineAccess {
     WispTask getWispTaskById(long id);
 
     Thread.State getState(Thread thread);
+
+    /**
+     * @param channel     Blocking SocketChannel waiting for interestOps
+     * @param interestOps Net.* enum constant interests
+     * @param timeout     timeout in milliseconds
+     * @return active event count
+     * @throws IOException
+     */
+    int poll(SelectableChannel channel, int interestOps, long timeout) throws IOException;
 }

--- a/src/java.base/share/classes/sun/nio/ch/IOStatus.java
+++ b/src/java.base/share/classes/sun/nio/ch/IOStatus.java
@@ -81,4 +81,12 @@ public final class IOStatus {
         return ((n > EOF) || (n < UNSUPPORTED_CASE));
     }
 
+    /**
+     * Returns true if the error code is UNAVAILABLE or INTERRUPTED, the
+     * error codes to indicate that an I/O operation can be retried.
+     */
+    static boolean okayToRetry(long n) {
+        return (n == IOStatus.UNAVAILABLE) || (n == IOStatus.INTERRUPTED);
+    }
+
 }

--- a/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
@@ -25,8 +25,13 @@
 
 package sun.nio.ch;
 
+import com.alibaba.wisp.engine.WispEngine;
+import jdk.internal.misc.SharedSecrets;
+import jdk.internal.misc.WispEngineAccess;
+
 import java.io.FileDescriptor;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.ClosedChannelException;
@@ -41,6 +46,8 @@ class SinkChannelImpl
     extends Pipe.SinkChannel
     implements SelChImpl
 {
+    private static final WispEngineAccess WEA = SharedSecrets.getWispEngineAccess();
+
     // Used to make native read and write calls
     private static final NativeDispatcher nd = new FileDispatcherImpl();
 
@@ -82,6 +89,11 @@ class SinkChannelImpl
         super(sp);
         this.fd = fd;
         this.fdVal = IOUtil.fdVal(fd);
+        try {
+            configureAsNonBlockingForWisp(fd);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unexpected error at configureAsNonBlockingForWisp", e);
+        }
     }
 
     /**
@@ -254,7 +266,15 @@ class SinkChannelImpl
                 beginWrite(blocking);
                 do {
                     n = IOUtil.write(fd, src, -1, nd);
-                } while ((n == IOStatus.INTERRUPTED) && isOpen());
+                    if ((n == IOStatus.INTERRUPTED) && isOpen()) {
+                        continue;
+                    }
+                    if (WispEngine.transparentWispSwitch() && isBlocking() && IOStatus.okayToRetry(n)) {
+                        WEA.poll(this, Net.POLLOUT, -1);
+                        continue;
+                    }
+                    break;
+                } while (true);
             } finally {
                 endWrite(blocking, n > 0);
                 assert IOStatus.check(n);
@@ -277,7 +297,15 @@ class SinkChannelImpl
                 beginWrite(blocking);
                 do {
                     n = IOUtil.write(fd, srcs, offset, length, nd);
-                } while ((n == IOStatus.INTERRUPTED) && isOpen());
+                    if ((n == IOStatus.INTERRUPTED) && isOpen()) {
+                        continue;
+                    }
+                    if (WispEngine.transparentWispSwitch() && isBlocking() && IOStatus.okayToRetry(n)) {
+                        WEA.poll(this, Net.POLLOUT, -1);
+                        continue;
+                    }
+                    break;
+                } while (true);
             } finally {
                 endWrite(blocking, n > 0);
                 assert IOStatus.check(n);

--- a/src/java.base/windows/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/windows/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -177,6 +177,11 @@ public class WispEngine {
             public Thread.State getState(Thread thread) {
                 return null;
             }
+
+            @Override
+            public int poll(SelectableChannel channel, int interestOps, long timeout) throws IOException {
+                throw new UnsupportedOperationException();
+            }
         });
     }
 

--- a/test/jdk/com/alibaba/wisp/io/TestBlockingNIO.java
+++ b/test/jdk/com/alibaba/wisp/io/TestBlockingNIO.java
@@ -1,0 +1,182 @@
+/*
+ * @test
+ * @library /lib/testlibrary
+ * @summary test blocking nio
+ * @requires os.family == "linux"
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestBlockingNIO
+ */
+
+import com.alibaba.wisp.engine.WispEngine;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Pipe;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.testlibrary.Asserts.*;
+
+
+public class TestBlockingNIO {
+    static CountDownLatch latch = new CountDownLatch(1);
+
+    public static void main(String[] args) throws Exception {
+        BlockingSemantic();
+        Accept2Test();
+        PipeTest();
+        AdaptorTest();
+
+        boolean te = false;
+        try {
+            TimeOutTest();
+        } catch (SocketTimeoutException e) {
+            te = true;
+        }
+
+        assertTrue(te);
+        assertTrue(latch.getCount() == 1);
+    }
+
+    static void BlockingSemantic() throws Exception {
+
+        WispEngine.dispatch(() -> {
+            try {
+                ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+                serverSocketChannel.bind(new InetSocketAddress(12312));
+                serverSocketChannel.configureBlocking(true);
+                serverSocketChannel.accept();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    static void Accept2Test() throws Exception {
+        CountDownLatch serverReady = new CountDownLatch(1);
+        CountDownLatch reading = new CountDownLatch(1);
+
+        Thread t = new Thread(() -> {
+            try {
+                serverReady.await(1, TimeUnit.SECONDS);
+                SocketChannel s = SocketChannel.open();
+                s.connect(new InetSocketAddress(12388));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t.start();
+        Thread t2 = new Thread(() -> {
+            try {
+                ServerSocketChannel ssc = ServerSocketChannel.open();
+                ssc.configureBlocking(true);
+                ssc.bind(new InetSocketAddress(12388));
+                serverReady.countDown();
+                SocketChannel channel = ssc.accept();
+                reading.countDown();
+                channel.read(ByteBuffer.allocate(203));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t2.start();
+
+        reading.await();
+        CountDownLatch suc = new CountDownLatch(1);
+        new Thread(() -> {
+            try {
+                Thread.sleep(2_000L);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            suc.countDown();
+        }).start();
+
+        suc.await();
+    }
+
+
+    static void PipeTest() throws Exception {
+        Pipe pipe = Pipe.open();
+        Pipe.SinkChannel sinkChannel = pipe.sink();
+        Pipe.SourceChannel sourceChannel = pipe.source();
+
+        CountDownLatch blocking = new CountDownLatch(1);
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    blocking.countDown();
+                    sourceChannel.read(ByteBuffer.allocate(44));
+                    // should block
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }).start();
+
+        blocking.await();
+
+        CountDownLatch suc = new CountDownLatch(1);
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                suc.countDown();
+            }
+        }).start();
+
+        suc.await();// if carrier is blocking in nio this may hang here
+    }
+
+
+    static void AdaptorTest() throws Exception {
+
+        CountDownLatch serverStarted = new CountDownLatch(1);
+        Thread t2 = new Thread(() -> {
+            try {
+                ServerSocketChannel ssc = ServerSocketChannel.open();
+                ssc.configureBlocking(true);
+                ssc.bind(new InetSocketAddress(12388));
+                ssc.accept();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t2.start();
+
+
+        Thread t1 = new Thread(() -> {
+            try {
+                SocketChannel channel = SocketChannel.open();
+                channel.configureBlocking(true);
+                channel.socket().setSoTimeout(200000);
+                channel.socket().connect(new InetSocketAddress(12388));
+                int v = channel.socket().getInputStream().read(new byte[2031]);
+                System.out.println(v);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        t1.start();
+
+
+        CountDownLatch latch = new CountDownLatch(1);
+        WispEngine.dispatch(latch::countDown);
+
+        latch.await();
+    }
+
+    static void TimeOutTest() throws Exception {
+        ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        serverSocketChannel.configureBlocking(true);
+        serverSocketChannel.socket().setSoTimeout(200);
+        serverSocketChannel.socket().bind(new InetSocketAddress(2333));
+        serverSocketChannel.socket().accept();
+    }
+}


### PR DESCRIPTION
Summary: Hook blocking entry at pipeChannel and SocketChannel,
  current WispTask would block itself to wait for next scheduling.

Test Plan: jtreg TestBlockIngIO.

Reviewed-by: zhengxiaolinX, ddh

Issue: alibaba/dragonwell11#272