### PR TITLE
[Backport] 8234391 C2: Generic vector operands & 8234392 C2: Extend Matcher::match_rule_supported_vector() with element type information

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2319,6 +2319,24 @@ const bool Matcher::require_postalloc_expand = false;
 // the cpu only look at the lower 5/6 bits anyway?
 const bool Matcher::need_masked_shift_count = false;
 
+// No support for generic vector operands.
+const bool Matcher::supports_generic_vector_operands  = false;
+
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+  ShouldNotReachHere(); // generic vector operands not supported
+  return NULL;
+}
+
+bool Matcher::is_generic_reg2reg_move(MachNode* m) {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
+bool Matcher::is_generic_vector(MachOper* opnd)  {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
 // This affects two different things:
 //  - how Decode nodes are matched
 //  - how ImplicitNullCheck opportunities are recognized

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1219,6 +1219,24 @@ const bool Matcher::need_masked_shift_count = true;
 
 const bool Matcher::convi2l_type_required = true;
 
+// No support for generic vector operands.
+const bool Matcher::supports_generic_vector_operands  = false;
+
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+  ShouldNotReachHere(); // generic vector operands not supported
+  return NULL;
+}
+
+bool Matcher::is_generic_reg2reg_move(MachNode* m) {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
+bool Matcher::is_generic_vector(MachOper* opnd)  {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
 // Should the Matcher clone shifts on addressing modes, expecting them
 // to be subsumed into complex addressing expressions or compute them
 // into registers?

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2377,6 +2377,24 @@ const bool Matcher::require_postalloc_expand = true;
 // PowerPC requires masked shift counts.
 const bool Matcher::need_masked_shift_count = true;
 
+// No support for generic vector operands.
+const bool Matcher::supports_generic_vector_operands  = false;
+
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+  ShouldNotReachHere(); // generic vector operands not supported
+  return NULL;
+}
+
+bool Matcher::is_generic_reg2reg_move(MachNode* m) {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
+bool Matcher::is_generic_vector(MachOper* opnd)  {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
 // This affects two different things:
 //  - how Decode nodes are matched
 //  - how ImplicitNullCheck opportunities are recognized

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1629,6 +1629,24 @@ const bool Matcher::require_postalloc_expand = false;
 // Constant shift counts are handled in Ideal phase.
 const bool Matcher::need_masked_shift_count = false;
 
+// No support for generic vector operands.
+const bool Matcher::supports_generic_vector_operands  = false;
+
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+  ShouldNotReachHere(); // generic vector operands not supported
+  return NULL;
+}
+
+bool Matcher::is_generic_reg2reg_move(MachNode* m) {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
+bool Matcher::is_generic_vector(MachOper* opnd)  {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
 // Set this as clone_shift_expressions.
 bool Matcher::narrow_oop_use_complex_address() {
   if (Universe::narrow_oop_base() == NULL && Universe::narrow_oop_shift() == 0) return true;

--- a/src/hotspot/cpu/sparc/sparc.ad
+++ b/src/hotspot/cpu/sparc/sparc.ad
@@ -1814,6 +1814,24 @@ const bool Matcher::require_postalloc_expand = false;
 // the cpu only look at the lower 5/6 bits anyway?
 const bool Matcher::need_masked_shift_count = false;
 
+// No support for generic vector operands.
+const bool Matcher::supports_generic_vector_operands  = false;
+
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+  ShouldNotReachHere(); // generic vector operands not supported
+  return NULL;
+}
+
+bool Matcher::is_generic_reg2reg_move(MachNode* m) {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
+bool Matcher::is_generic_vector(MachOper* opnd)  {
+  ShouldNotReachHere();  // generic vector operands not supported
+  return false;
+}
+
 bool Matcher::narrow_oop_use_complex_address() {
   assert(UseCompressedOops, "only for compressed oops code");
   return false;

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1094,7 +1094,7 @@ reg_class vectorz_reg_legacy(XMM0,  XMM0b,  XMM0c,  XMM0d,  XMM0e,  XMM0f,  XMM0
 #endif
                       );
 
-reg_class_dynamic vectorz_reg(vectorz_reg_evex, vectorz_reg_legacy, %{ VM_Version::supports_evex() %} );
+reg_class_dynamic vectorz_reg   (vectorz_reg_evex, vectorz_reg_legacy, %{ VM_Version::supports_evex() %} );
 reg_class_dynamic vectorz_reg_vl(vectorz_reg_evex, vectorz_reg_legacy, %{ VM_Version::supports_evex() && VM_Version::supports_avx512vl() %} );
 
 reg_class xmm0_reg(XMM0, XMM0b, XMM0c, XMM0d);
@@ -1584,6 +1584,54 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
   return true;  // Per default match rules are supported.
 }
 
+// x86 supports generic vector operands: vec and legVec.
+const bool Matcher::supports_generic_vector_operands = true;
+
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* generic_opnd, uint ideal_reg) {
+  assert(Matcher::is_generic_vector(generic_opnd), "not generic");
+  bool legacy = (generic_opnd->opcode() == LEGVEC);
+  if (legacy) {
+    switch (ideal_reg) {
+      case Op_VecS: return new legVecSOper();
+      case Op_VecD: return new legVecDOper();
+      case Op_VecX: return new legVecXOper();
+      case Op_VecY: return new legVecYOper();
+      case Op_VecZ: return new legVecZOper();
+    }
+  } else {
+    switch (ideal_reg) {
+      case Op_VecS: return new vecSOper();
+      case Op_VecD: return new vecDOper();
+      case Op_VecX: return new vecXOper();
+      case Op_VecY: return new vecYOper();
+      case Op_VecZ: return new vecZOper();
+    }
+  }
+  ShouldNotReachHere();
+  return NULL;
+}
+
+bool Matcher::is_generic_reg2reg_move(MachNode* m) {
+  switch (m->rule()) {
+    case MoveVec2Leg_rule:
+    case MoveLeg2Vec_rule:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool Matcher::is_generic_vector(MachOper* opnd) {
+  switch (opnd->opcode()) {
+    case VEC:
+    case LEGVEC:
+      return true;
+    default:
+      return false;
+  }
+}
+
+//------------------------------------------------------------------------
 
 const bool Matcher::has_predicated_vectors(void) {
   bool ret_value = false;
@@ -2093,6 +2141,111 @@ encode %{
 // in the ADLC because operands constitute user defined types which are used in
 // instruction definitions.
 
+// Vectors
+
+// Dummy generic vector class. Should be used for all vector operands.
+// Replaced with vec[SDXYZ] during post-selection pass.
+operand vec() %{
+  constraint(ALLOC_IN_RC(dynamic));
+  match(VecX);
+  match(VecY);
+  match(VecZ);
+  match(VecS);
+  match(VecD);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Dummy generic legacy vector class. Should be used for all legacy vector operands.
+// Replaced with legVec[SDXYZ] during post-selection cleanup.
+// Note: legacy register class is used to avoid extra (unneeded in 32-bit VM)
+// runtime code generation via reg_class_dynamic.
+operand legVec() %{
+  constraint(ALLOC_IN_RC(dynamic));
+  match(VecX);
+  match(VecY);
+  match(VecZ);
+  match(VecS);
+  match(VecD);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces vec during post-selection cleanup. See above.
+operand vecS() %{
+  constraint(ALLOC_IN_RC(vectors_reg_vlbwdq));
+  match(VecS);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces legVec during post-selection cleanup. See above.
+operand legVecS() %{
+  constraint(ALLOC_IN_RC(vectors_reg_legacy));
+  match(VecS);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces vec during post-selection cleanup. See above.
+operand vecD() %{
+  constraint(ALLOC_IN_RC(vectord_reg_vlbwdq));
+  match(VecD);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces legVec during post-selection cleanup. See above.
+operand legVecD() %{
+  constraint(ALLOC_IN_RC(vectord_reg_legacy));
+  match(VecD);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces vec during post-selection cleanup. See above.
+operand vecX() %{
+  constraint(ALLOC_IN_RC(vectorx_reg_vlbwdq));
+  match(VecX);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces legVec during post-selection cleanup. See above.
+operand legVecX() %{
+  constraint(ALLOC_IN_RC(vectorx_reg_legacy));
+  match(VecX);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces vec during post-selection cleanup. See above.
+operand vecY() %{
+  constraint(ALLOC_IN_RC(vectory_reg_vlbwdq));
+  match(VecY);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces legVec during post-selection cleanup. See above.
+operand legVecY() %{
+  constraint(ALLOC_IN_RC(vectory_reg_legacy));
+  match(VecY);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Replaces vec during post-selection cleanup. See above.
 operand vecZ() %{
   constraint(ALLOC_IN_RC(vectorz_reg));
   match(VecZ);
@@ -2101,6 +2254,7 @@ operand vecZ() %{
   interface(REG_INTER);
 %}
 
+// Replaces legVec during post-selection cleanup. See above.
 operand legVecZ() %{
   constraint(ALLOC_IN_RC(vectorz_reg_legacy));
   match(VecZ);
@@ -2935,7 +3089,7 @@ instruct roundD_imm(legRegD dst, immD con, immU8 rmode, rRegI scratch_reg) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vround2D_reg(legVecX dst, legVecX src, immU8 rmode) %{
+instruct vround2D_reg(legVec dst, legVec src, immU8 rmode) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (RoundDoubleModeV src rmode));
   format %{ "vroundpd  $dst, $src, $rmode\t! round packed2D" %}
@@ -2946,7 +3100,7 @@ instruct vround2D_reg(legVecX dst, legVecX src, immU8 rmode) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vround2D_mem(legVecX dst, memory mem, immU8 rmode) %{
+instruct vround2D_mem(legVec dst, memory mem, immU8 rmode) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (RoundDoubleModeV (LoadVector mem) rmode));
   format %{ "vroundpd $dst, $mem, $rmode\t! round packed2D" %}
@@ -2957,7 +3111,7 @@ instruct vround2D_mem(legVecX dst, memory mem, immU8 rmode) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vround4D_reg(legVecY dst, legVecY src, legVecY rmode) %{
+instruct vround4D_reg(legVec dst, legVec src, legVec rmode) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (RoundDoubleModeV src rmode));
   format %{ "vroundpd  $dst, $src, $rmode\t! round packed4D" %}
@@ -2968,7 +3122,7 @@ instruct vround4D_reg(legVecY dst, legVecY src, legVecY rmode) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vround4D_mem(legVecY dst, memory mem, immU8 rmode) %{
+instruct vround4D_mem(legVec dst, memory mem, immU8 rmode) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (RoundDoubleModeV (LoadVector mem) rmode));
   format %{ "vroundpd $dst, $mem, $rmode\t! round packed4D" %}
@@ -2980,7 +3134,7 @@ instruct vround4D_mem(legVecY dst, memory mem, immU8 rmode) %{
 %}
 
 
-instruct vround8D_reg(vecZ dst, vecZ src, immU8 rmode) %{
+instruct vround8D_reg(vec dst, vec src, immU8 rmode) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (RoundDoubleModeV src rmode));
   format %{ "vrndscalepd $dst, $src, $rmode\t! round packed8D" %}
@@ -2991,7 +3145,7 @@ instruct vround8D_reg(vecZ dst, vecZ src, immU8 rmode) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vround8D_mem(vecZ dst, memory mem, immU8 rmode) %{
+instruct vround8D_mem(vec dst, memory mem, immU8 rmode) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (RoundDoubleModeV (LoadVector mem) rmode));
   format %{ "vrndscalepd $dst, $mem, $rmode\t! round packed8D" %}
@@ -3047,9 +3201,27 @@ instruct fmaF_reg(regF a, regF b, regF c) %{
 
 // ====================VECTOR INSTRUCTIONS=====================================
 
+// Dummy reg-to-reg vector moves. Removed during post-selection cleanup.
+instruct MoveVec2Leg(legVec dst, vec src) %{
+  match(Set dst src);
+  format %{ "" %}
+  ins_encode %{
+    ShouldNotReachHere();
+  %}
+  ins_pipe( fpu_reg_reg );
+%}
+
+instruct MoveLeg2Vec(vec dst, legVec src) %{
+  match(Set dst src);
+  format %{ "" %}
+  ins_encode %{
+    ShouldNotReachHere();
+  %}
+  ins_pipe( fpu_reg_reg );
+%}
 
 // Load vectors (4 bytes long)
-instruct loadV4(vecS dst, memory mem) %{
+instruct loadV4(vec dst, memory mem) %{
   predicate(n->as_LoadVector()->memory_size() == 4);
   match(Set dst (LoadVector mem));
   ins_cost(125);
@@ -3060,28 +3232,8 @@ instruct loadV4(vecS dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-// Load vectors (4 bytes long)
-instruct MoveVecS2Leg(legVecS dst, vecS src) %{
-  match(Set dst src);
-  format %{ "movss $dst,$src\t! load vector (4 bytes)" %}
-  ins_encode %{
-    __ movflt($dst$$XMMRegister, $src$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Load vectors (4 bytes long)
-instruct MoveLeg2VecS(vecS dst, legVecS src) %{
-  match(Set dst src);
-  format %{ "movss $dst,$src\t! load vector (4 bytes)" %}
-  ins_encode %{
-    __ movflt($dst$$XMMRegister, $src$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
 // Load vectors (8 bytes long)
-instruct loadV8(vecD dst, memory mem) %{
+instruct loadV8(vec dst, memory mem) %{
   predicate(n->as_LoadVector()->memory_size() == 8);
   match(Set dst (LoadVector mem));
   ins_cost(125);
@@ -3092,28 +3244,8 @@ instruct loadV8(vecD dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-// Load vectors (8 bytes long)
-instruct MoveVecD2Leg(legVecD dst, vecD src) %{
-  match(Set dst src);
-  format %{ "movsd $dst,$src\t! load vector (8 bytes)" %}
-  ins_encode %{
-    __ movdbl($dst$$XMMRegister, $src$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Load vectors (8 bytes long)
-instruct MoveLeg2VecD(vecD dst, legVecD src) %{
-  match(Set dst src);
-  format %{ "movsd $dst,$src\t! load vector (8 bytes)" %}
-  ins_encode %{
-    __ movdbl($dst$$XMMRegister, $src$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
 // Load vectors (16 bytes long)
-instruct loadV16(vecX dst, memory mem) %{
+instruct loadV16(vec dst, memory mem) %{
   predicate(n->as_LoadVector()->memory_size() == 16);
   match(Set dst (LoadVector mem));
   ins_cost(125);
@@ -3124,38 +3256,8 @@ instruct loadV16(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-// Load vectors (16 bytes long)
-instruct MoveVecX2Leg(legVecX dst, vecX src) %{
-  match(Set dst src);
-  format %{ "movdqu $dst,$src\t! load vector (16 bytes)" %}
-  ins_encode %{
-    if (UseAVX > 2 && !VM_Version::supports_avx512vl()) {
-      int vector_len = 2;
-      __ evmovdquq($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-    } else {
-      __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
-    }
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Load vectors (16 bytes long)
-instruct MoveLeg2VecX(vecX dst, legVecX src) %{
-  match(Set dst src);
-  format %{ "movdqu $dst,$src\t! load vector (16 bytes)" %}
-  ins_encode %{
-    if (UseAVX > 2 && !VM_Version::supports_avx512vl()) {
-      int vector_len = 2;
-      __ evmovdquq($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-    } else {
-      __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
-    }
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
 // Load vectors (32 bytes long)
-instruct loadV32(vecY dst, memory mem) %{
+instruct loadV32(vec dst, memory mem) %{
   predicate(n->as_LoadVector()->memory_size() == 32);
   match(Set dst (LoadVector mem));
   ins_cost(125);
@@ -3166,38 +3268,8 @@ instruct loadV32(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-// Load vectors (32 bytes long)
-instruct MoveVecY2Leg(legVecY dst, vecY src) %{
-  match(Set dst src);
-  format %{ "vmovdqu $dst,$src\t! load vector (32 bytes)" %}
-  ins_encode %{
-    if (UseAVX > 2 && !VM_Version::supports_avx512vl()) {
-      int vector_len = 2;
-      __ evmovdquq($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-    } else {
-      __ vmovdqu($dst$$XMMRegister, $src$$XMMRegister);
-    }
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Load vectors (32 bytes long)
-instruct MoveLeg2VecY(vecY dst, legVecY src) %{
-  match(Set dst src);
-  format %{ "vmovdqu $dst,$src\t! load vector (32 bytes)" %}
-  ins_encode %{
-    if (UseAVX > 2 && !VM_Version::supports_avx512vl()) {
-      int vector_len = 2;
-      __ evmovdquq($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-    } else {
-      __ vmovdqu($dst$$XMMRegister, $src$$XMMRegister);
-    }
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
 // Load vectors (64 bytes long)
-instruct loadV64_dword(vecZ dst, memory mem) %{
+instruct loadV64_dword(vec dst, memory mem) %{
   predicate(n->as_LoadVector()->memory_size() == 64 && n->as_LoadVector()->element_size() <= 4);
   match(Set dst (LoadVector mem));
   ins_cost(125);
@@ -3210,7 +3282,7 @@ instruct loadV64_dword(vecZ dst, memory mem) %{
 %}
 
 // Load vectors (64 bytes long)
-instruct loadV64_qword(vecZ dst, memory mem) %{
+instruct loadV64_qword(vec dst, memory mem) %{
   predicate(n->as_LoadVector()->memory_size() == 64 && n->as_LoadVector()->element_size() > 4);
   match(Set dst (LoadVector mem));
   ins_cost(125);
@@ -3222,28 +3294,8 @@ instruct loadV64_qword(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct MoveVecZ2Leg(legVecZ dst, vecZ  src) %{
-  match(Set dst src);
-  format %{ "vmovdquq $dst k0,$src\t! Move vector (64 bytes)" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ evmovdquq($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct MoveLeg2VecZ(vecZ dst, legVecZ  src) %{
-  match(Set dst src);
-  format %{ "vmovdquq $dst k0,$src\t! Move vector (64 bytes)" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ evmovdquq($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
 // Store vectors
-instruct storeV4(memory mem, vecS src) %{
+instruct storeV4(memory mem, vec src) %{
   predicate(n->as_StoreVector()->memory_size() == 4);
   match(Set mem (StoreVector mem src));
   ins_cost(145);
@@ -3254,7 +3306,7 @@ instruct storeV4(memory mem, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct storeV8(memory mem, vecD src) %{
+instruct storeV8(memory mem, vec src) %{
   predicate(n->as_StoreVector()->memory_size() == 8);
   match(Set mem (StoreVector mem src));
   ins_cost(145);
@@ -3265,7 +3317,7 @@ instruct storeV8(memory mem, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct storeV16(memory mem, vecX src) %{
+instruct storeV16(memory mem, vec src) %{
   predicate(n->as_StoreVector()->memory_size() == 16);
   match(Set mem (StoreVector mem src));
   ins_cost(145);
@@ -3276,7 +3328,7 @@ instruct storeV16(memory mem, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct storeV32(memory mem, vecY src) %{
+instruct storeV32(memory mem, vec src) %{
   predicate(n->as_StoreVector()->memory_size() == 32);
   match(Set mem (StoreVector mem src));
   ins_cost(145);
@@ -3287,7 +3339,7 @@ instruct storeV32(memory mem, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct storeV64_dword(memory mem, vecZ src) %{
+instruct storeV64_dword(memory mem, vec src) %{
   predicate(n->as_StoreVector()->memory_size() == 64 && n->as_StoreVector()->element_size() <= 4);
   match(Set mem (StoreVector mem src));
   ins_cost(145);
@@ -3299,7 +3351,7 @@ instruct storeV64_dword(memory mem, vecZ src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct storeV64_qword(memory mem, vecZ src) %{
+instruct storeV64_qword(memory mem, vec src) %{
   predicate(n->as_StoreVector()->memory_size() == 64 && n->as_StoreVector()->element_size() > 4);
   match(Set mem (StoreVector mem src));
   ins_cost(145);
@@ -3313,7 +3365,7 @@ instruct storeV64_qword(memory mem, vecZ src) %{
 
 // ====================LEGACY REPLICATE=======================================
 
-instruct Repl16B(vecX dst, rRegI src) %{
+instruct Repl16B(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB src));
   format %{ "movd    $dst,$src\n\t"
@@ -3329,7 +3381,7 @@ instruct Repl16B(vecX dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32B(vecY dst, rRegI src) %{
+instruct Repl32B(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB src));
   format %{ "movd    $dst,$src\n\t"
@@ -3347,7 +3399,7 @@ instruct Repl32B(vecY dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl64B(legVecZ dst, rRegI src) %{
+instruct Repl64B(legVec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 64 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB src));
   format %{ "movd    $dst,$src\n\t"
@@ -3367,7 +3419,7 @@ instruct Repl64B(legVecZ dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16B_imm(vecX dst, immI con) %{
+instruct Repl16B_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3379,7 +3431,7 @@ instruct Repl16B_imm(vecX dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32B_imm(vecY dst, immI con) %{
+instruct Repl32B_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3393,7 +3445,7 @@ instruct Repl32B_imm(vecY dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl64B_imm(legVecZ dst, immI con) %{
+instruct Repl64B_imm(legVec dst, immI con) %{
   predicate(n->as_Vector()->length() == 64 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3409,7 +3461,7 @@ instruct Repl64B_imm(legVecZ dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4S(vecD dst, rRegI src) %{
+instruct Repl4S(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS src));
   format %{ "movd    $dst,$src\n\t"
@@ -3421,7 +3473,7 @@ instruct Repl4S(vecD dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4S_mem(vecD dst, memory mem) %{
+instruct Repl4S_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "pshuflw $dst,$mem,0x00\t! replicate4S" %}
@@ -3431,7 +3483,7 @@ instruct Repl4S_mem(vecD dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8S(vecX dst, rRegI src) %{
+instruct Repl8S(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS src));
   format %{ "movd    $dst,$src\n\t"
@@ -3445,7 +3497,7 @@ instruct Repl8S(vecX dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8S_mem(vecX dst, memory mem) %{
+instruct Repl8S_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 0 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "pshuflw $dst,$mem,0x00\n\t"
@@ -3457,7 +3509,7 @@ instruct Repl8S_mem(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8S_imm(vecX dst, immI con) %{
+instruct Repl8S_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3469,7 +3521,7 @@ instruct Repl8S_imm(vecX dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16S(vecY dst, rRegI src) %{
+instruct Repl16S(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS src));
   format %{ "movd    $dst,$src\n\t"
@@ -3485,7 +3537,7 @@ instruct Repl16S(vecY dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16S_mem(vecY dst, memory mem) %{
+instruct Repl16S_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "pshuflw $dst,$mem,0x00\n\t"
@@ -3499,7 +3551,7 @@ instruct Repl16S_mem(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16S_imm(vecY dst, immI con) %{
+instruct Repl16S_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3513,7 +3565,7 @@ instruct Repl16S_imm(vecY dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32S(legVecZ dst, rRegI src) %{
+instruct Repl32S(legVec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS src));
   format %{ "movd    $dst,$src\n\t"
@@ -3531,7 +3583,7 @@ instruct Repl32S(legVecZ dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32S_mem(legVecZ dst, memory mem) %{
+instruct Repl32S_mem(legVec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "pshuflw $dst,$mem,0x00\n\t"
@@ -3547,7 +3599,7 @@ instruct Repl32S_mem(legVecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32S_imm(legVecZ dst, immI con) %{
+instruct Repl32S_imm(legVec dst, immI con) %{
   predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3563,7 +3615,7 @@ instruct Repl32S_imm(legVecZ dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4I(vecX dst, rRegI src) %{
+instruct Repl4I(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI src));
   format %{ "movd    $dst,$src\n\t"
@@ -3575,7 +3627,7 @@ instruct Repl4I(vecX dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4I_mem(vecX dst, memory mem) %{
+instruct Repl4I_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "pshufd  $dst,$mem,0x00\t! replicate4I" %}
@@ -3585,7 +3637,7 @@ instruct Repl4I_mem(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8I(vecY dst, rRegI src) %{
+instruct Repl8I(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI src));
   format %{ "movd    $dst,$src\n\t"
@@ -3599,7 +3651,7 @@ instruct Repl8I(vecY dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8I_mem(vecY dst, memory mem) %{
+instruct Repl8I_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "pshufd  $dst,$mem,0x00\n\t"
@@ -3611,7 +3663,7 @@ instruct Repl8I_mem(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16I(legVecZ dst, rRegI src) %{
+instruct Repl16I(legVec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI src));
   format %{ "movd    $dst,$src\n\t"
@@ -3627,7 +3679,7 @@ instruct Repl16I(legVecZ dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16I_mem(legVecZ dst, memory mem) %{
+instruct Repl16I_mem(legVec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "pshufd  $dst,$mem,0x00\n\t"
@@ -3641,7 +3693,7 @@ instruct Repl16I_mem(legVecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4I_imm(vecX dst, immI con) %{
+instruct Repl4I_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate4I($con)\n\t"
@@ -3653,7 +3705,7 @@ instruct Repl4I_imm(vecX dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8I_imm(vecY dst, immI con) %{
+instruct Repl8I_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate8I($con)\n\t"
@@ -3667,7 +3719,7 @@ instruct Repl8I_imm(vecY dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16I_imm(legVecZ dst, immI con) %{
+instruct Repl16I_imm(legVec dst, immI con) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI con));
   format %{ "movq    $dst,[$constantaddress]\t"
@@ -3684,7 +3736,7 @@ instruct Repl16I_imm(legVecZ dst, immI con) %{
 %}
 
 // Long could be loaded into xmm register directly from memory.
-instruct Repl2L_mem(vecX dst, memory mem) %{
+instruct Repl2L_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 2 && !VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateL (LoadL mem)));
   format %{ "movq    $dst,$mem\n\t"
@@ -3698,7 +3750,7 @@ instruct Repl2L_mem(vecX dst, memory mem) %{
 
 // Replicate long (8 byte) scalar to be vector
 #ifdef _LP64
-instruct Repl4L(vecY dst, rRegL src) %{
+instruct Repl4L(vec dst, rRegL src) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL src));
   format %{ "movdq   $dst,$src\n\t"
@@ -3712,7 +3764,7 @@ instruct Repl4L(vecY dst, rRegL src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L(legVecZ dst, rRegL src) %{
+instruct Repl8L(legVec dst, rRegL src) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL src));
   format %{ "movdq   $dst,$src\n\t"
@@ -3728,7 +3780,7 @@ instruct Repl8L(legVecZ dst, rRegL src) %{
   ins_pipe( pipe_slow );
 %}
 #else // _LP64
-instruct Repl4L(vecY dst, eRegL src, vecY tmp) %{
+instruct Repl4L(vec dst, eRegL src, vec tmp) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
@@ -3747,7 +3799,7 @@ instruct Repl4L(vecY dst, eRegL src, vecY tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L(legVecZ dst, eRegL src, legVecZ tmp) %{
+instruct Repl8L(legVec dst, eRegL src, legVec tmp) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
@@ -3769,7 +3821,7 @@ instruct Repl8L(legVecZ dst, eRegL src, legVecZ tmp) %{
 %}
 #endif // _LP64
 
-instruct Repl4L_imm(vecY dst, immL con) %{
+instruct Repl4L_imm(vec dst, immL con) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3783,7 +3835,7 @@ instruct Repl4L_imm(vecY dst, immL con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L_imm(legVecZ dst, immL con) %{
+instruct Repl8L_imm(legVec dst, immL con) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -3799,7 +3851,7 @@ instruct Repl8L_imm(legVecZ dst, immL con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4L_mem(vecY dst, memory mem) %{
+instruct Repl4L_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL (LoadL mem)));
   format %{ "movq    $dst,$mem\n\t"
@@ -3813,7 +3865,7 @@ instruct Repl4L_mem(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L_mem(legVecZ dst, memory mem) %{
+instruct Repl8L_mem(legVec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL (LoadL mem)));
   format %{ "movq    $dst,$mem\n\t"
@@ -3829,7 +3881,7 @@ instruct Repl8L_mem(legVecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl2F_mem(vecD dst, memory mem) %{
+instruct Repl2F_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 2 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF (LoadF mem)));
   format %{ "pshufd  $dst,$mem,0x00\t! replicate2F" %}
@@ -3839,7 +3891,7 @@ instruct Repl2F_mem(vecD dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4F_mem(vecX dst, memory mem) %{
+instruct Repl4F_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF (LoadF mem)));
   format %{ "pshufd  $dst,$mem,0x00\t! replicate4F" %}
@@ -3849,7 +3901,7 @@ instruct Repl4F_mem(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8F(vecY dst, vlRegF src) %{
+instruct Repl8F(vec dst, vlRegF src) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF src));
   format %{ "pshufd  $dst,$src,0x00\n\t"
@@ -3861,7 +3913,7 @@ instruct Repl8F(vecY dst, vlRegF src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8F_mem(vecY dst, memory mem) %{
+instruct Repl8F_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF (LoadF mem)));
   format %{ "pshufd  $dst,$mem,0x00\n\t"
@@ -3873,7 +3925,7 @@ instruct Repl8F_mem(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16F(legVecZ dst, vlRegF src) %{
+instruct Repl16F(legVec dst, vlRegF src) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF src));
   format %{ "pshufd  $dst,$src,0x00\n\t"
@@ -3887,7 +3939,7 @@ instruct Repl16F(legVecZ dst, vlRegF src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16F_mem(legVecZ dst, memory mem) %{
+instruct Repl16F_mem(legVec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF (LoadF mem)));
   format %{ "pshufd  $dst,$mem,0x00\n\t"
@@ -3901,7 +3953,7 @@ instruct Repl16F_mem(legVecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl2F_zero(vecD dst, immF0 zero) %{
+instruct Repl2F_zero(vec dst, immF0 zero) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateF zero));
   format %{ "xorps   $dst,$dst\t! replicate2F zero" %}
@@ -3911,7 +3963,7 @@ instruct Repl2F_zero(vecD dst, immF0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4F_zero(vecX dst, immF0 zero) %{
+instruct Repl4F_zero(vec dst, immF0 zero) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateF zero));
   format %{ "xorps   $dst,$dst\t! replicate4F zero" %}
@@ -3921,7 +3973,7 @@ instruct Repl4F_zero(vecX dst, immF0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl8F_zero(vecY dst, immF0 zero) %{
+instruct Repl8F_zero(vec dst, immF0 zero) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 0);
   match(Set dst (ReplicateF zero));
   format %{ "vxorps  $dst,$dst,$dst\t! replicate8F zero" %}
@@ -3932,7 +3984,7 @@ instruct Repl8F_zero(vecY dst, immF0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl2D_mem(vecX dst, memory mem) %{
+instruct Repl2D_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 2 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD (LoadD mem)));
   format %{ "pshufd  $dst,$mem,0x44\t! replicate2D" %}
@@ -3942,7 +3994,7 @@ instruct Repl2D_mem(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4D(vecY dst, vlRegD src) %{
+instruct Repl4D(vec dst, vlRegD src) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD src));
   format %{ "pshufd  $dst,$src,0x44\n\t"
@@ -3954,7 +4006,7 @@ instruct Repl4D(vecY dst, vlRegD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4D_mem(vecY dst, memory mem) %{
+instruct Repl4D_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD (LoadD mem)));
   format %{ "pshufd  $dst,$mem,0x44\n\t"
@@ -3966,7 +4018,7 @@ instruct Repl4D_mem(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8D(legVecZ dst, vlRegD src) %{
+instruct Repl8D(legVec dst, vlRegD src) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 0 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD src));
   format %{ "pshufd  $dst,$src,0x44\n\t"
@@ -3980,7 +4032,7 @@ instruct Repl8D(legVecZ dst, vlRegD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8D_mem(legVecZ dst, memory mem) %{
+instruct Repl8D_mem(legVec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD (LoadD mem)));
   format %{ "pshufd  $dst,$mem,0x44\n\t"
@@ -3995,7 +4047,7 @@ instruct Repl8D_mem(legVecZ dst, memory mem) %{
 %}
 
 // Replicate double (8 byte) scalar zero to be vector
-instruct Repl2D_zero(vecX dst, immD0 zero) %{
+instruct Repl2D_zero(vec dst, immD0 zero) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateD zero));
   format %{ "xorpd   $dst,$dst\t! replicate2D zero" %}
@@ -4005,7 +4057,7 @@ instruct Repl2D_zero(vecX dst, immD0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4D_zero(vecY dst, immD0 zero) %{
+instruct Repl4D_zero(vec dst, immD0 zero) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 0);
   match(Set dst (ReplicateD zero));
   format %{ "vxorpd  $dst,$dst,$dst,vect256\t! replicate4D zero" %}
@@ -4019,7 +4071,7 @@ instruct Repl4D_zero(vecY dst, immD0 zero) %{
 // ====================GENERIC REPLICATE==========================================
 
 // Replicate byte scalar to be vector
-instruct Repl4B(vecS dst, rRegI src) %{
+instruct Repl4B(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateB src));
   format %{ "movd    $dst,$src\n\t"
@@ -4033,7 +4085,7 @@ instruct Repl4B(vecS dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8B(vecD dst, rRegI src) %{
+instruct Repl8B(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (ReplicateB src));
   format %{ "movd    $dst,$src\n\t"
@@ -4048,7 +4100,7 @@ instruct Repl8B(vecD dst, rRegI src) %{
 %}
 
 // Replicate byte scalar immediate to be vector by loading from const table.
-instruct Repl4B_imm(vecS dst, immI con) %{
+instruct Repl4B_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateB con));
   format %{ "movdl   $dst,[$constantaddress]\t! replicate4B($con)" %}
@@ -4058,7 +4110,7 @@ instruct Repl4B_imm(vecS dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8B_imm(vecD dst, immI con) %{
+instruct Repl8B_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (ReplicateB con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate8B($con)" %}
@@ -4069,7 +4121,7 @@ instruct Repl8B_imm(vecD dst, immI con) %{
 %}
 
 // Replicate byte scalar zero to be vector
-instruct Repl4B_zero(vecS dst, immI0 zero) %{
+instruct Repl4B_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateB zero));
   format %{ "pxor    $dst,$dst\t! replicate4B zero" %}
@@ -4079,7 +4131,7 @@ instruct Repl4B_zero(vecS dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl8B_zero(vecD dst, immI0 zero) %{
+instruct Repl8B_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (ReplicateB zero));
   format %{ "pxor    $dst,$dst\t! replicate8B zero" %}
@@ -4089,7 +4141,7 @@ instruct Repl8B_zero(vecD dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl16B_zero(vecX dst, immI0 zero) %{
+instruct Repl16B_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (ReplicateB zero));
   format %{ "pxor    $dst,$dst\t! replicate16B zero" %}
@@ -4099,7 +4151,7 @@ instruct Repl16B_zero(vecX dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl32B_zero(vecY dst, immI0 zero) %{
+instruct Repl32B_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 32);
   match(Set dst (ReplicateB zero));
   format %{ "vpxor   $dst,$dst,$dst\t! replicate32B zero" %}
@@ -4112,7 +4164,7 @@ instruct Repl32B_zero(vecY dst, immI0 zero) %{
 %}
 
 // Replicate char/short (2 byte) scalar to be vector
-instruct Repl2S(vecS dst, rRegI src) %{
+instruct Repl2S(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateS src));
   format %{ "movd    $dst,$src\n\t"
@@ -4125,7 +4177,7 @@ instruct Repl2S(vecS dst, rRegI src) %{
 %}
 
 // Replicate char/short (2 byte) scalar immediate to be vector by loading from const table.
-instruct Repl2S_imm(vecS dst, immI con) %{
+instruct Repl2S_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateS con));
   format %{ "movdl   $dst,[$constantaddress]\t! replicate2S($con)" %}
@@ -4135,7 +4187,7 @@ instruct Repl2S_imm(vecS dst, immI con) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4S_imm(vecD dst, immI con) %{
+instruct Repl4S_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateS con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate4S($con)" %}
@@ -4146,7 +4198,7 @@ instruct Repl4S_imm(vecD dst, immI con) %{
 %}
 
 // Replicate char/short (2 byte) scalar zero to be vector
-instruct Repl2S_zero(vecS dst, immI0 zero) %{
+instruct Repl2S_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateS zero));
   format %{ "pxor    $dst,$dst\t! replicate2S zero" %}
@@ -4156,7 +4208,7 @@ instruct Repl2S_zero(vecS dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4S_zero(vecD dst, immI0 zero) %{
+instruct Repl4S_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateS zero));
   format %{ "pxor    $dst,$dst\t! replicate4S zero" %}
@@ -4166,7 +4218,7 @@ instruct Repl4S_zero(vecD dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl8S_zero(vecX dst, immI0 zero) %{
+instruct Repl8S_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (ReplicateS zero));
   format %{ "pxor    $dst,$dst\t! replicate8S zero" %}
@@ -4176,7 +4228,7 @@ instruct Repl8S_zero(vecX dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl16S_zero(vecY dst, immI0 zero) %{
+instruct Repl16S_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (ReplicateS zero));
   format %{ "vpxor   $dst,$dst,$dst\t! replicate16S zero" %}
@@ -4189,7 +4241,7 @@ instruct Repl16S_zero(vecY dst, immI0 zero) %{
 %}
 
 // Replicate integer (4 byte) scalar to be vector
-instruct Repl2I(vecD dst, rRegI src) %{
+instruct Repl2I(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateI src));
   format %{ "movd    $dst,$src\n\t"
@@ -4202,7 +4254,7 @@ instruct Repl2I(vecD dst, rRegI src) %{
 %}
 
 // Integer could be loaded into xmm register directly from memory.
-instruct Repl2I_mem(vecD dst, memory mem) %{
+instruct Repl2I_mem(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "movd    $dst,$mem\n\t"
@@ -4215,7 +4267,7 @@ instruct Repl2I_mem(vecD dst, memory mem) %{
 %}
 
 // Replicate integer (4 byte) scalar immediate to be vector by loading from const table.
-instruct Repl2I_imm(vecD dst, immI con) %{
+instruct Repl2I_imm(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateI con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate2I($con)" %}
@@ -4226,7 +4278,7 @@ instruct Repl2I_imm(vecD dst, immI con) %{
 %}
 
 // Replicate integer (4 byte) scalar zero to be vector
-instruct Repl2I_zero(vecD dst, immI0 zero) %{
+instruct Repl2I_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateI zero));
   format %{ "pxor    $dst,$dst\t! replicate2I" %}
@@ -4236,7 +4288,7 @@ instruct Repl2I_zero(vecD dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4I_zero(vecX dst, immI0 zero) %{
+instruct Repl4I_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateI zero));
   format %{ "pxor    $dst,$dst\t! replicate4I zero)" %}
@@ -4246,7 +4298,7 @@ instruct Repl4I_zero(vecX dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl8I_zero(vecY dst, immI0 zero) %{
+instruct Repl8I_zero(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (ReplicateI zero));
   format %{ "vpxor   $dst,$dst,$dst\t! replicate8I zero" %}
@@ -4260,7 +4312,7 @@ instruct Repl8I_zero(vecY dst, immI0 zero) %{
 
 // Replicate long (8 byte) scalar to be vector
 #ifdef _LP64
-instruct Repl2L(vecX dst, rRegL src) %{
+instruct Repl2L(vec dst, rRegL src) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateL src));
   format %{ "movdq   $dst,$src\n\t"
@@ -4272,7 +4324,7 @@ instruct Repl2L(vecX dst, rRegL src) %{
   ins_pipe( pipe_slow );
 %}
 #else // _LP64
-instruct Repl2L(vecX dst, eRegL src, vecX tmp) %{
+instruct Repl2L(vec dst, eRegL src, vec tmp) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
@@ -4291,7 +4343,7 @@ instruct Repl2L(vecX dst, eRegL src, vecX tmp) %{
 #endif // _LP64
 
 // Replicate long (8 byte) scalar immediate to be vector by loading from const table.
-instruct Repl2L_imm(vecX dst, immL con) %{
+instruct Repl2L_imm(vec dst, immL con) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateL con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4304,7 +4356,7 @@ instruct Repl2L_imm(vecX dst, immL con) %{
 %}
 
 // Replicate long (8 byte) scalar zero to be vector
-instruct Repl2L_zero(vecX dst, immL0 zero) %{
+instruct Repl2L_zero(vec dst, immL0 zero) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateL zero));
   format %{ "pxor    $dst,$dst\t! replicate2L zero" %}
@@ -4314,7 +4366,7 @@ instruct Repl2L_zero(vecX dst, immL0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4L_zero(vecY dst, immL0 zero) %{
+instruct Repl4L_zero(vec dst, immL0 zero) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateL zero));
   format %{ "vpxor   $dst,$dst,$dst\t! replicate4L zero" %}
@@ -4327,7 +4379,7 @@ instruct Repl4L_zero(vecY dst, immL0 zero) %{
 %}
 
 // Replicate float (4 byte) scalar to be vector
-instruct Repl2F(vecD dst, vlRegF src) %{
+instruct Repl2F(vec dst, vlRegF src) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateF src));
   format %{ "pshufd  $dst,$dst,0x00\t! replicate2F" %}
@@ -4337,7 +4389,7 @@ instruct Repl2F(vecD dst, vlRegF src) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4F(vecX dst, vlRegF src) %{
+instruct Repl4F(vec dst, vlRegF src) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (ReplicateF src));
   format %{ "pshufd  $dst,$dst,0x00\t! replicate4F" %}
@@ -4348,7 +4400,7 @@ instruct Repl4F(vecX dst, vlRegF src) %{
 %}
 
 // Replicate double (8 bytes) scalar to be vector
-instruct Repl2D(vecX dst, vlRegD src) %{
+instruct Repl2D(vec dst, vlRegD src) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (ReplicateD src));
   format %{ "pshufd  $dst,$src,0x44\t! replicate2D" %}
@@ -4360,7 +4412,7 @@ instruct Repl2D(vecX dst, vlRegD src) %{
 
 // ====================EVEX REPLICATE=============================================
 
-instruct Repl4B_mem_evex(vecS dst, memory mem) %{
+instruct Repl4B_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB (LoadB mem)));
   format %{ "vpbroadcastb  $dst,$mem\t! replicate4B" %}
@@ -4371,7 +4423,7 @@ instruct Repl4B_mem_evex(vecS dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8B_mem_evex(vecD dst, memory mem) %{
+instruct Repl8B_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB (LoadB mem)));
   format %{ "vpbroadcastb  $dst,$mem\t! replicate8B" %}
@@ -4382,7 +4434,7 @@ instruct Repl8B_mem_evex(vecD dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16B_evex(vecX dst, rRegI src) %{
+instruct Repl16B_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB src));
   format %{ "evpbroadcastb $dst,$src\t! replicate16B" %}
@@ -4393,7 +4445,7 @@ instruct Repl16B_evex(vecX dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16B_mem_evex(vecX dst, memory mem) %{
+instruct Repl16B_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB (LoadB mem)));
   format %{ "vpbroadcastb  $dst,$mem\t! replicate16B" %}
@@ -4404,7 +4456,7 @@ instruct Repl16B_mem_evex(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32B_evex(vecY dst, rRegI src) %{
+instruct Repl32B_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB src));
   format %{ "evpbroadcastb $dst,$src\t! replicate32B" %}
@@ -4415,7 +4467,7 @@ instruct Repl32B_evex(vecY dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32B_mem_evex(vecY dst, memory mem) %{
+instruct Repl32B_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB (LoadB mem)));
   format %{ "vpbroadcastb  $dst,$mem\t! replicate32B" %}
@@ -4426,7 +4478,7 @@ instruct Repl32B_mem_evex(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl64B_evex(vecZ dst, rRegI src) %{
+instruct Repl64B_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 64 && UseAVX > 2 && VM_Version::supports_avx512bw());
   match(Set dst (ReplicateB src));
   format %{ "evpbroadcastb $dst,$src\t! upper replicate64B" %}
@@ -4437,7 +4489,7 @@ instruct Repl64B_evex(vecZ dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl64B_mem_evex(vecZ dst, memory mem) %{
+instruct Repl64B_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 64 && UseAVX > 2 && VM_Version::supports_avx512bw());
   match(Set dst (ReplicateB (LoadB mem)));
   format %{ "vpbroadcastb  $dst,$mem\t! replicate64B" %}
@@ -4448,7 +4500,7 @@ instruct Repl64B_mem_evex(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16B_imm_evex(vecX dst, immI con) %{
+instruct Repl16B_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4461,7 +4513,7 @@ instruct Repl16B_imm_evex(vecX dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32B_imm_evex(vecY dst, immI con) %{
+instruct Repl32B_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateB con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4474,7 +4526,7 @@ instruct Repl32B_imm_evex(vecY dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl64B_imm_evex(vecZ dst, immI con) %{
+instruct Repl64B_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 64 && UseAVX > 2 && VM_Version::supports_avx512bw());
   match(Set dst (ReplicateB con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4487,7 +4539,7 @@ instruct Repl64B_imm_evex(vecZ dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl64B_zero_evex(vecZ dst, immI0 zero) %{
+instruct Repl64B_zero_evex(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 64 && UseAVX > 2);
   match(Set dst (ReplicateB zero));
   format %{ "vpxor   $dst k0,$dst,$dst\t! replicate64B zero" %}
@@ -4499,7 +4551,7 @@ instruct Repl64B_zero_evex(vecZ dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4S_evex(vecD dst, rRegI src) %{
+instruct Repl4S_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS src));
   format %{ "evpbroadcastw $dst,$src\t! replicate4S" %}
@@ -4510,7 +4562,7 @@ instruct Repl4S_evex(vecD dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4S_mem_evex(vecD dst, memory mem) %{
+instruct Repl4S_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "vpbroadcastw  $dst,$mem\t! replicate4S" %}
@@ -4521,7 +4573,7 @@ instruct Repl4S_mem_evex(vecD dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8S_evex(vecX dst, rRegI src) %{
+instruct Repl8S_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS src));
   format %{ "evpbroadcastw $dst,$src\t! replicate8S" %}
@@ -4532,7 +4584,7 @@ instruct Repl8S_evex(vecX dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8S_mem_evex(vecX dst, memory mem) %{
+instruct Repl8S_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "vpbroadcastw  $dst,$mem\t! replicate8S" %}
@@ -4543,7 +4595,7 @@ instruct Repl8S_mem_evex(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16S_evex(vecY dst, rRegI src) %{
+instruct Repl16S_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS src));
   format %{ "evpbroadcastw $dst,$src\t! replicate16S" %}
@@ -4554,7 +4606,7 @@ instruct Repl16S_evex(vecY dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16S_mem_evex(vecY dst, memory mem) %{
+instruct Repl16S_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "vpbroadcastw  $dst,$mem\t! replicate16S" %}
@@ -4565,7 +4617,7 @@ instruct Repl16S_mem_evex(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32S_evex(vecZ dst, rRegI src) %{
+instruct Repl32S_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512bw());
   match(Set dst (ReplicateS src));
   format %{ "evpbroadcastw $dst,$src\t! replicate32S" %}
@@ -4576,7 +4628,7 @@ instruct Repl32S_evex(vecZ dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32S_mem_evex(vecZ dst, memory mem) %{
+instruct Repl32S_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512bw());
   match(Set dst (ReplicateS (LoadS mem)));
   format %{ "vpbroadcastw  $dst,$mem\t! replicate32S" %}
@@ -4587,7 +4639,7 @@ instruct Repl32S_mem_evex(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8S_imm_evex(vecX dst, immI con) %{
+instruct Repl8S_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4600,7 +4652,7 @@ instruct Repl8S_imm_evex(vecX dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16S_imm_evex(vecY dst, immI con) %{
+instruct Repl16S_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
   match(Set dst (ReplicateS con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4613,7 +4665,7 @@ instruct Repl16S_imm_evex(vecY dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32S_imm_evex(vecZ dst, immI con) %{
+instruct Repl32S_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512bw());
   match(Set dst (ReplicateS con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4626,7 +4678,7 @@ instruct Repl32S_imm_evex(vecZ dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl32S_zero_evex(vecZ dst, immI0 zero) %{
+instruct Repl32S_zero_evex(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 32 && UseAVX > 2);
   match(Set dst (ReplicateS zero));
   format %{ "vpxor   $dst k0,$dst,$dst\t! replicate32S zero" %}
@@ -4638,7 +4690,7 @@ instruct Repl32S_zero_evex(vecZ dst, immI0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4I_evex(vecX dst, rRegI src) %{
+instruct Repl4I_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI src));
   format %{ "evpbroadcastd  $dst,$src\t! replicate4I" %}
@@ -4649,7 +4701,7 @@ instruct Repl4I_evex(vecX dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4I_mem_evex(vecX dst, memory mem) %{
+instruct Repl4I_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "vpbroadcastd  $dst,$mem\t! replicate4I" %}
@@ -4660,7 +4712,7 @@ instruct Repl4I_mem_evex(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8I_evex(vecY dst, rRegI src) %{
+instruct Repl8I_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI src));
   format %{ "evpbroadcastd  $dst,$src\t! replicate8I" %}
@@ -4671,7 +4723,7 @@ instruct Repl8I_evex(vecY dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8I_mem_evex(vecY dst, memory mem) %{
+instruct Repl8I_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "vpbroadcastd  $dst,$mem\t! replicate8I" %}
@@ -4682,7 +4734,7 @@ instruct Repl8I_mem_evex(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16I_evex(vecZ dst, rRegI src) %{
+instruct Repl16I_evex(vec dst, rRegI src) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
   match(Set dst (ReplicateI src));
   format %{ "evpbroadcastd  $dst,$src\t! replicate16I" %}
@@ -4693,7 +4745,7 @@ instruct Repl16I_evex(vecZ dst, rRegI src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16I_mem_evex(vecZ dst, memory mem) %{
+instruct Repl16I_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
   match(Set dst (ReplicateI (LoadI mem)));
   format %{ "vpbroadcastd  $dst,$mem\t! replicate16I" %}
@@ -4704,7 +4756,7 @@ instruct Repl16I_mem_evex(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4I_imm_evex(vecX dst, immI con) %{
+instruct Repl4I_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate8I($con)\n\t"
@@ -4717,7 +4769,7 @@ instruct Repl4I_imm_evex(vecX dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8I_imm_evex(vecY dst, immI con) %{
+instruct Repl8I_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateI con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate8I($con)\n\t"
@@ -4730,7 +4782,7 @@ instruct Repl8I_imm_evex(vecY dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16I_imm_evex(vecZ dst, immI con) %{
+instruct Repl16I_imm_evex(vec dst, immI con) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
   match(Set dst (ReplicateI con));
   format %{ "movq    $dst,[$constantaddress]\t! replicate16I($con)\n\t"
@@ -4743,7 +4795,7 @@ instruct Repl16I_imm_evex(vecZ dst, immI con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16I_zero_evex(vecZ dst, immI0 zero) %{
+instruct Repl16I_zero_evex(vec dst, immI0 zero) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
   match(Set dst (ReplicateI zero));
   format %{ "vpxor   $dst k0,$dst,$dst\t! replicate16I zero" %}
@@ -4757,7 +4809,7 @@ instruct Repl16I_zero_evex(vecZ dst, immI0 zero) %{
 
 // Replicate long (8 byte) scalar to be vector
 #ifdef _LP64
-instruct Repl4L_evex(vecY dst, rRegL src) %{
+instruct Repl4L_evex(vec dst, rRegL src) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL src));
   format %{ "evpbroadcastq  $dst,$src\t! replicate4L" %}
@@ -4768,7 +4820,7 @@ instruct Repl4L_evex(vecY dst, rRegL src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L_evex(vecZ dst, rRegL src) %{
+instruct Repl8L_evex(vec dst, rRegL src) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateL src));
   format %{ "evpbroadcastq  $dst,$src\t! replicate8L" %}
@@ -4779,7 +4831,7 @@ instruct Repl8L_evex(vecZ dst, rRegL src) %{
   ins_pipe( pipe_slow );
 %}
 #else // _LP64
-instruct Repl4L_evex(vecY dst, eRegL src, regD tmp) %{
+instruct Repl4L_evex(vec dst, eRegL src, regD tmp) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
@@ -4797,7 +4849,7 @@ instruct Repl4L_evex(vecY dst, eRegL src, regD tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L_evex(legVecZ dst, eRegL src, legVecZ tmp) %{
+instruct Repl8L_evex(legVec dst, eRegL src, legVec tmp) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
@@ -4816,7 +4868,7 @@ instruct Repl8L_evex(legVecZ dst, eRegL src, legVecZ tmp) %{
 %}
 #endif // _LP64
 
-instruct Repl4L_imm_evex(vecY dst, immL con) %{
+instruct Repl4L_imm_evex(vec dst, immL con) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4829,7 +4881,7 @@ instruct Repl4L_imm_evex(vecY dst, immL con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L_imm_evex(vecZ dst, immL con) %{
+instruct Repl8L_imm_evex(vec dst, immL con) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateL con));
   format %{ "movq    $dst,[$constantaddress]\n\t"
@@ -4842,7 +4894,7 @@ instruct Repl8L_imm_evex(vecZ dst, immL con) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl2L_mem_evex(vecX dst, memory mem) %{
+instruct Repl2L_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 2 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL (LoadL mem)));
   format %{ "vpbroadcastd  $dst,$mem\t! replicate2L" %}
@@ -4853,7 +4905,7 @@ instruct Repl2L_mem_evex(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4L_mem_evex(vecY dst, memory mem) %{
+instruct Repl4L_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateL (LoadL mem)));
   format %{ "vpbroadcastd  $dst,$mem\t! replicate4L" %}
@@ -4864,7 +4916,7 @@ instruct Repl4L_mem_evex(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L_mem_evex(vecZ dst, memory mem) %{
+instruct Repl8L_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateL (LoadL mem)));
   format %{ "vpbroadcastd  $dst,$mem\t! replicate8L" %}
@@ -4875,7 +4927,7 @@ instruct Repl8L_mem_evex(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8L_zero_evex(vecZ dst, immL0 zero) %{
+instruct Repl8L_zero_evex(vec dst, immL0 zero) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateL zero));
   format %{ "vpxor   $dst k0,$dst,$dst\t! replicate8L zero" %}
@@ -4887,7 +4939,7 @@ instruct Repl8L_zero_evex(vecZ dst, immL0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl8F_evex(vecY dst, regF src) %{
+instruct Repl8F_evex(vec dst, regF src) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF src));
   format %{ "vpbroadcastss $dst,$src\t! replicate8F" %}
@@ -4898,7 +4950,7 @@ instruct Repl8F_evex(vecY dst, regF src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8F_mem_evex(vecY dst, memory mem) %{
+instruct Repl8F_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateF (LoadF mem)));
   format %{ "vbroadcastss  $dst,$mem\t! replicate8F" %}
@@ -4909,7 +4961,7 @@ instruct Repl8F_mem_evex(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16F_evex(vecZ dst, regF src) %{
+instruct Repl16F_evex(vec dst, regF src) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
   match(Set dst (ReplicateF src));
   format %{ "vpbroadcastss $dst,$src\t! replicate16F" %}
@@ -4920,7 +4972,7 @@ instruct Repl16F_evex(vecZ dst, regF src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16F_mem_evex(vecZ dst, memory mem) %{
+instruct Repl16F_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
   match(Set dst (ReplicateF (LoadF mem)));
   format %{ "vbroadcastss  $dst,$mem\t! replicate16F" %}
@@ -4931,7 +4983,7 @@ instruct Repl16F_mem_evex(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl16F_zero_evex(vecZ dst, immF0 zero) %{
+instruct Repl16F_zero_evex(vec dst, immF0 zero) %{
   predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
   match(Set dst (ReplicateF zero));
   format %{ "vpxor  $dst k0,$dst,$dst\t! replicate16F zero" %}
@@ -4943,7 +4995,7 @@ instruct Repl16F_zero_evex(vecZ dst, immF0 zero) %{
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4D_evex(vecY dst, regD src) %{
+instruct Repl4D_evex(vec dst, regD src) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD src));
   format %{ "vpbroadcastsd $dst,$src\t! replicate4D" %}
@@ -4954,7 +5006,7 @@ instruct Repl4D_evex(vecY dst, regD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl4D_mem_evex(vecY dst, memory mem) %{
+instruct Repl4D_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD (LoadD mem)));
   format %{ "vbroadcastsd  $dst,$mem\t! replicate4D" %}
@@ -4965,7 +5017,7 @@ instruct Repl4D_mem_evex(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8D_evex(vecZ dst, regD src) %{
+instruct Repl8D_evex(vec dst, regD src) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateD src));
   format %{ "vpbroadcastsd $dst,$src\t! replicate8D" %}
@@ -4976,7 +5028,7 @@ instruct Repl8D_evex(vecZ dst, regD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8D_mem_evex(vecZ dst, memory mem) %{
+instruct Repl8D_mem_evex(vec dst, memory mem) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateD (LoadD mem)));
   format %{ "vbroadcastsd  $dst,$mem\t! replicate8D" %}
@@ -4987,7 +5039,7 @@ instruct Repl8D_mem_evex(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8D_zero_evex(vecZ dst, immD0 zero) %{
+instruct Repl8D_zero_evex(vec dst, immD0 zero) %{
   predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
   match(Set dst (ReplicateD zero));
   format %{ "vpxor  $dst k0,$dst,$dst,vect512\t! replicate8D zero" %}
@@ -5001,8 +5053,8 @@ instruct Repl8D_zero_evex(vecZ dst, immD0 zero) %{
 
 // ====================REDUCTION ARITHMETIC=======================================
 
-instruct rsadd2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD tmp2) %{
-  predicate(UseSSE > 2 && UseAVX == 0);
+instruct rsadd2I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseSSE > 2 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp2, TEMP tmp);
   format %{ "movdqu  $tmp2,$src2\n\t"
@@ -5020,8 +5072,8 @@ instruct rsadd2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD tmp2) %{
-  predicate(VM_Version::supports_avxonly());
+instruct rvadd2I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && VM_Version::supports_avxonly() && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vphaddd  $tmp,$src2,$src2\n\t"
@@ -5038,8 +5090,8 @@ instruct rvadd2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd2I_reduction_reg_evex(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvadd2I_reduction_reg_evex(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd  $tmp2,$src2,0x1\n\t"
@@ -5058,8 +5110,8 @@ instruct rvadd2I_reduction_reg_evex(rRegI dst, rRegI src1, vecD src2, vecD tmp, 
   ins_pipe( pipe_slow );
 %}
 
-instruct rsadd4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX tmp2) %{
-  predicate(UseSSE > 2 && UseAVX == 0);
+instruct rsadd4I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseSSE > 2 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "movdqu  $tmp,$src2\n\t"
@@ -5079,8 +5131,8 @@ instruct rsadd4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX tmp2) %{
-  predicate(VM_Version::supports_avxonly());
+instruct rvadd4I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && VM_Version::supports_avxonly() && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vphaddd  $tmp,$src2,$src2\n\t"
@@ -5099,8 +5151,8 @@ instruct rvadd4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd4I_reduction_reg_evex(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvadd4I_reduction_reg_evex(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd  $tmp2,$src2,0xE\n\t"
@@ -5123,8 +5175,8 @@ instruct rvadd4I_reduction_reg_evex(rRegI dst, rRegI src1, vecX src2, vecX tmp, 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd8I_reduction_reg(rRegI dst, rRegI src1, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(VM_Version::supports_avxonly());
+instruct rvadd8I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && VM_Version::supports_avxonly() && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vphaddd  $tmp,$src2,$src2\n\t"
@@ -5147,8 +5199,8 @@ instruct rvadd8I_reduction_reg(rRegI dst, rRegI src1, vecY src2, vecY tmp, vecY 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd8I_reduction_reg_evex(rRegI dst, rRegI src1, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvadd8I_reduction_reg_evex(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vextracti128_high  $tmp,$src2\n\t"
@@ -5175,8 +5227,8 @@ instruct rvadd8I_reduction_reg_evex(rRegI dst, rRegI src1, vecY src2, vecY tmp, 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd16I_reduction_reg_evex(rRegI dst, rRegI src1, legVecZ src2, legVecZ tmp, legVecZ tmp2, legVecZ tmp3) %{
-  predicate(UseAVX > 2);
+instruct rvadd16I_reduction_reg_evex(rRegI dst, rRegI src1, legVec src2, legVec tmp, legVec tmp2, legVec tmp3) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 16);
   match(Set dst (AddReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2, TEMP tmp3);
   format %{ "vextracti64x4_high  $tmp3,$src2\n\t"
@@ -5207,8 +5259,8 @@ instruct rvadd16I_reduction_reg_evex(rRegI dst, rRegI src1, legVecZ src2, legVec
 %}
 
 #ifdef _LP64
-instruct rvadd2L_reduction_reg(rRegL dst, rRegL src1, vecX src2, vecX tmp, vecX tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvadd2L_reduction_reg(rRegL dst, rRegL src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVL src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd  $tmp2,$src2,0xE\n\t"
@@ -5226,8 +5278,8 @@ instruct rvadd2L_reduction_reg(rRegL dst, rRegL src1, vecX src2, vecX tmp, vecX 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd4L_reduction_reg(rRegL dst, rRegL src1, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvadd4L_reduction_reg(rRegL dst, rRegL src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (AddReductionVL src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vextracti128_high  $tmp,$src2\n\t"
@@ -5249,8 +5301,8 @@ instruct rvadd4L_reduction_reg(rRegL dst, rRegL src1, vecY src2, vecY tmp, vecY 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd8L_reduction_reg(rRegL dst, rRegL src1, legVecZ src2, legVecZ tmp, legVecZ tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvadd8L_reduction_reg(rRegL dst, rRegL src1, legVec src2, legVec tmp, legVec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (AddReductionVL src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vextracti64x4_high  $tmp2,$src2\n\t"
@@ -5277,8 +5329,8 @@ instruct rvadd8L_reduction_reg(rRegL dst, rRegL src1, legVecZ src2, legVecZ tmp,
 %}
 #endif
 
-instruct rsadd2F_reduction_reg(regF dst, vecD src2, vecD tmp) %{
-  predicate(UseSSE >= 1 && UseAVX == 0);
+instruct rsadd2F_reduction_reg(regF dst, vec src2, vec tmp) %{
+  predicate(UseSSE >= 1 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVF dst src2));
   effect(TEMP dst, TEMP tmp);
   format %{ "addss   $dst,$src2\n\t"
@@ -5292,8 +5344,8 @@ instruct rsadd2F_reduction_reg(regF dst, vecD src2, vecD tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd2F_reduction_reg(regF dst, vecD src2, vecD tmp) %{
-  predicate(UseAVX > 0);
+instruct rvadd2F_reduction_reg(regF dst, vec src2, vec tmp) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVF dst src2));
   effect(TEMP dst, TEMP tmp);
   format %{ "vaddss  $dst,$dst,$src2\n\t"
@@ -5307,8 +5359,8 @@ instruct rvadd2F_reduction_reg(regF dst, vecD src2, vecD tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rsadd4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
-  predicate(UseSSE >= 1 && UseAVX == 0);
+instruct rsadd4F_reduction_reg(regF dst, vec src2, vec tmp) %{
+  predicate(UseSSE >= 1 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (AddReductionVF dst src2));
   effect(TEMP dst, TEMP tmp);
   format %{ "addss   $dst,$src2\n\t"
@@ -5330,8 +5382,8 @@ instruct rsadd4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
-  predicate(UseAVX > 0);
+instruct rvadd4F_reduction_reg(regF dst, vec src2, vec tmp) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (AddReductionVF dst src2));
   effect(TEMP tmp, TEMP dst);
   format %{ "vaddss  $dst,dst,$src2\n\t"
@@ -5353,8 +5405,8 @@ instruct rvadd4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct radd8F_reduction_reg(regF dst, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(UseAVX > 0);
+instruct radd8F_reduction_reg(regF dst, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (AddReductionVF dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vaddss  $dst,$dst,$src2\n\t"
@@ -5392,8 +5444,8 @@ instruct radd8F_reduction_reg(regF dst, vecY src2, vecY tmp, vecY tmp2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct radd16F_reduction_reg(regF dst, legVecZ src2, legVecZ tmp, legVecZ tmp2) %{
-  predicate(UseAVX > 2);
+instruct radd16F_reduction_reg(regF dst, legVec src2, legVec tmp, legVec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 16);
   match(Set dst (AddReductionVF dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vaddss  $dst,$dst,$src2\n\t"
@@ -5463,8 +5515,8 @@ instruct radd16F_reduction_reg(regF dst, legVecZ src2, legVecZ tmp, legVecZ tmp2
   ins_pipe( pipe_slow );
 %}
 
-instruct rsadd2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
-  predicate(UseSSE >= 1 && UseAVX == 0);
+instruct rsadd2D_reduction_reg(regD dst, vec src2, vec tmp) %{
+  predicate(UseSSE >= 1 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVD dst src2));
   effect(TEMP tmp, TEMP dst);
   format %{ "addsd   $dst,$src2\n\t"
@@ -5478,8 +5530,8 @@ instruct rsadd2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
-  predicate(UseAVX > 0);
+instruct rvadd2D_reduction_reg(regD dst, vec src2, vec tmp) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (AddReductionVD dst src2));
   effect(TEMP tmp, TEMP dst);
   format %{ "vaddsd  $dst,$dst,$src2\n\t"
@@ -5493,8 +5545,8 @@ instruct rvadd2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd4D_reduction_reg(regD dst, vecY src2, vecX tmp, vecX tmp2) %{
-  predicate(UseAVX > 0);
+instruct rvadd4D_reduction_reg(regD dst, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (AddReductionVD dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vaddsd  $dst,$dst,$src2\n\t"
@@ -5516,8 +5568,8 @@ instruct rvadd4D_reduction_reg(regD dst, vecY src2, vecX tmp, vecX tmp2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvadd8D_reduction_reg(regD dst, legVecZ src2, legVecZ tmp, legVecZ tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvadd8D_reduction_reg(regD dst, legVec src2, legVec tmp, legVec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (AddReductionVD dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vaddsd  $dst,$dst,$src2\n\t"
@@ -5555,8 +5607,8 @@ instruct rvadd8D_reduction_reg(regD dst, legVecZ src2, legVecZ tmp, legVecZ tmp2
   ins_pipe( pipe_slow );
 %}
 
-instruct rsmul2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD tmp2) %{
-  predicate(UseSSE > 3 && UseAVX == 0);
+instruct rsmul2I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseSSE > 3 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd  $tmp2,$src2,0x1\n\t"
@@ -5574,8 +5626,8 @@ instruct rsmul2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD tmp2) %{
-  predicate(UseAVX > 0);
+instruct rvmul2I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd   $tmp2,$src2,0x1\n\t"
@@ -5594,8 +5646,8 @@ instruct rvmul2I_reduction_reg(rRegI dst, rRegI src1, vecD src2, vecD tmp, vecD 
   ins_pipe( pipe_slow );
 %}
 
-instruct rsmul4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX tmp2) %{
-  predicate(UseSSE > 3 && UseAVX == 0);
+instruct rsmul4I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseSSE > 3 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd  $tmp2,$src2,0xE\n\t"
@@ -5617,8 +5669,8 @@ instruct rsmul4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX tmp2) %{
-  predicate(UseAVX > 0);
+instruct rvmul4I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd   $tmp2,$src2,0xE\n\t"
@@ -5641,8 +5693,8 @@ instruct rvmul4I_reduction_reg(rRegI dst, rRegI src1, vecX src2, vecX tmp, vecX 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul8I_reduction_reg(rRegI dst, rRegI src1, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(UseAVX > 1);
+instruct rvmul8I_reduction_reg(rRegI dst, rRegI src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 1 && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vextracti128_high  $tmp,$src2\n\t"
@@ -5669,8 +5721,8 @@ instruct rvmul8I_reduction_reg(rRegI dst, rRegI src1, vecY src2, vecY tmp, vecY 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul16I_reduction_reg(rRegI dst, rRegI src1, legVecZ src2, legVecZ tmp, legVecZ tmp2, legVecZ tmp3) %{
-  predicate(UseAVX > 2);
+instruct rvmul16I_reduction_reg(rRegI dst, rRegI src1, legVec src2, legVec tmp, legVec tmp2, legVec tmp3) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 16);
   match(Set dst (MulReductionVI src1 src2));
   effect(TEMP tmp, TEMP tmp2, TEMP tmp3);
   format %{ "vextracti64x4_high  $tmp3,$src2\n\t"
@@ -5701,8 +5753,8 @@ instruct rvmul16I_reduction_reg(rRegI dst, rRegI src1, legVecZ src2, legVecZ tmp
 %}
 
 #ifdef _LP64
-instruct rvmul2L_reduction_reg(rRegL dst, rRegL src1, vecX src2, vecX tmp, vecX tmp2) %{
-  predicate(UseAVX > 2 && VM_Version::supports_avx512dq());
+instruct rvmul2L_reduction_reg(rRegL dst, rRegL src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 2 && VM_Version::supports_avx512dq() && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (MulReductionVL src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "pshufd   $tmp2,$src2,0xE\n\t"
@@ -5720,8 +5772,8 @@ instruct rvmul2L_reduction_reg(rRegL dst, rRegL src1, vecX src2, vecX tmp, vecX 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul4L_reduction_reg(rRegL dst, rRegL src1, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(UseAVX > 2 && VM_Version::supports_avx512dq());
+instruct rvmul4L_reduction_reg(rRegL dst, rRegL src1, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 2 && VM_Version::supports_avx512dq() && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (MulReductionVL src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vextracti128_high  $tmp,$src2\n\t"
@@ -5743,8 +5795,8 @@ instruct rvmul4L_reduction_reg(rRegL dst, rRegL src1, vecY src2, vecY tmp, vecY 
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul8L_reduction_reg(rRegL dst, rRegL src1, legVecZ src2, legVecZ tmp, legVecZ tmp2) %{
-  predicate(UseAVX > 2 && VM_Version::supports_avx512dq());
+instruct rvmul8L_reduction_reg(rRegL dst, rRegL src1, legVec src2, legVec tmp, legVec tmp2) %{
+  predicate(UseAVX > 2 && VM_Version::supports_avx512dq() && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (MulReductionVL src1 src2));
   effect(TEMP tmp, TEMP tmp2);
   format %{ "vextracti64x4_high  $tmp2,$src2\n\t"
@@ -5771,8 +5823,8 @@ instruct rvmul8L_reduction_reg(rRegL dst, rRegL src1, legVecZ src2, legVecZ tmp,
 %}
 #endif
 
-instruct rsmul2F_reduction(regF dst, vecD src2, vecD tmp) %{
-  predicate(UseSSE >= 1 && UseAVX == 0);
+instruct rsmul2F_reduction(regF dst, vec src2, vec tmp) %{
+  predicate(UseSSE >= 1 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (MulReductionVF dst src2));
   effect(TEMP dst, TEMP tmp);
   format %{ "mulss   $dst,$src2\n\t"
@@ -5786,8 +5838,8 @@ instruct rsmul2F_reduction(regF dst, vecD src2, vecD tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul2F_reduction_reg(regF dst, vecD src2, vecD tmp) %{
-  predicate(UseAVX > 0);
+instruct rvmul2F_reduction_reg(regF dst, vec src2, vec tmp) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (MulReductionVF dst src2));
   effect(TEMP tmp, TEMP dst);
   format %{ "vmulss  $dst,$dst,$src2\n\t"
@@ -5801,8 +5853,8 @@ instruct rvmul2F_reduction_reg(regF dst, vecD src2, vecD tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rsmul4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
-  predicate(UseSSE >= 1 && UseAVX == 0);
+instruct rsmul4F_reduction_reg(regF dst, vec src2, vec tmp) %{
+  predicate(UseSSE >= 1 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (MulReductionVF dst src2));
   effect(TEMP dst, TEMP tmp);
   format %{ "mulss   $dst,$src2\n\t"
@@ -5824,8 +5876,8 @@ instruct rsmul4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
-  predicate(UseAVX > 0);
+instruct rvmul4F_reduction_reg(regF dst, vec src2, vec tmp) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (MulReductionVF dst src2));
   effect(TEMP tmp, TEMP dst);
   format %{ "vmulss  $dst,$dst,$src2\n\t"
@@ -5847,8 +5899,8 @@ instruct rvmul4F_reduction_reg(regF dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul8F_reduction_reg(regF dst, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(UseAVX > 0);
+instruct rvmul8F_reduction_reg(regF dst, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (MulReductionVF dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vmulss  $dst,$dst,$src2\n\t"
@@ -5886,8 +5938,8 @@ instruct rvmul8F_reduction_reg(regF dst, vecY src2, vecY tmp, vecY tmp2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul16F_reduction_reg(regF dst, legVecZ src2, legVecZ tmp, legVecZ tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvmul16F_reduction_reg(regF dst, legVec src2, legVec tmp, legVec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 16);
   match(Set dst (MulReductionVF dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vmulss  $dst,$dst,$src2\n\t"
@@ -5957,8 +6009,8 @@ instruct rvmul16F_reduction_reg(regF dst, legVecZ src2, legVecZ tmp, legVecZ tmp
   ins_pipe( pipe_slow );
 %}
 
-instruct rsmul2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
-  predicate(UseSSE >= 1 && UseAVX == 0);
+instruct rsmul2D_reduction_reg(regD dst, vec src2, vec tmp) %{
+  predicate(UseSSE >= 1 && UseAVX == 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (MulReductionVD dst src2));
   effect(TEMP dst, TEMP tmp);
   format %{ "mulsd   $dst,$src2\n\t"
@@ -5972,8 +6024,8 @@ instruct rsmul2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
-  predicate(UseAVX > 0);
+instruct rvmul2D_reduction_reg(regD dst, vec src2, vec tmp) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 2);
   match(Set dst (MulReductionVD dst src2));
   effect(TEMP tmp, TEMP dst);
   format %{ "vmulsd  $dst,$dst,$src2\n\t"
@@ -5987,8 +6039,8 @@ instruct rvmul2D_reduction_reg(regD dst, vecX src2, vecX tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul4D_reduction_reg(regD dst, vecY src2, vecY tmp, vecY tmp2) %{
-  predicate(UseAVX > 0);
+instruct rvmul4D_reduction_reg(regD dst, vec src2, vec tmp, vec tmp2) %{
+  predicate(UseAVX > 0 && n->in(2)->bottom_type()->is_vect()->length() == 4);
   match(Set dst (MulReductionVD dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vmulsd  $dst,$dst,$src2\n\t"
@@ -6010,8 +6062,8 @@ instruct rvmul4D_reduction_reg(regD dst, vecY src2, vecY tmp, vecY tmp2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct rvmul8D_reduction_reg(regD dst, legVecZ src2, legVecZ tmp, legVecZ tmp2) %{
-  predicate(UseAVX > 2);
+instruct rvmul8D_reduction_reg(regD dst, legVec src2, legVec tmp, legVec tmp2) %{
+  predicate(UseAVX > 2 && n->in(2)->bottom_type()->is_vect()->length() == 8);
   match(Set dst (MulReductionVD dst src2));
   effect(TEMP tmp, TEMP dst, TEMP tmp2);
   format %{ "vmulsd  $dst,$dst,$src2\n\t"
@@ -6054,7 +6106,7 @@ instruct rvmul8D_reduction_reg(regD dst, legVecZ src2, legVecZ tmp, legVecZ tmp2
 // --------------------------------- ADD --------------------------------------
 
 // Bytes vector add
-instruct vadd4B(vecS dst, vecS src) %{
+instruct vadd4B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVB dst src));
   format %{ "paddb   $dst,$src\t! add packed4B" %}
@@ -6064,7 +6116,7 @@ instruct vadd4B(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4B_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vadd4B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVB src1 src2));
   format %{ "vpaddb  $dst,$src1,$src2\t! add packed4B" %}
@@ -6076,7 +6128,7 @@ instruct vadd4B_reg(vecS dst, vecS src1, vecS src2) %{
 %}
 
 
-instruct vadd4B_mem(vecS dst, vecS src, memory mem) %{
+instruct vadd4B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVB src (LoadVector mem)));
@@ -6088,7 +6140,7 @@ instruct vadd4B_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8B(vecD dst, vecD src) %{
+instruct vadd8B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 8);
   match(Set dst (AddVB dst src));
   format %{ "paddb   $dst,$src\t! add packed8B" %}
@@ -6098,7 +6150,7 @@ instruct vadd8B(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8B_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vadd8B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (AddVB src1 src2));
   format %{ "vpaddb  $dst,$src1,$src2\t! add packed8B" %}
@@ -6110,7 +6162,7 @@ instruct vadd8B_reg(vecD dst, vecD src1, vecD src2) %{
 %}
 
 
-instruct vadd8B_mem(vecD dst, vecD src, memory mem) %{
+instruct vadd8B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 8) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVB src (LoadVector mem)));
@@ -6122,7 +6174,7 @@ instruct vadd8B_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16B(vecX dst, vecX src) %{
+instruct vadd16B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 16);
   match(Set dst (AddVB dst src));
   format %{ "paddb   $dst,$src\t! add packed16B" %}
@@ -6132,7 +6184,7 @@ instruct vadd16B(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16B_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vadd16B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0  && n->as_Vector()->length() == 16);
   match(Set dst (AddVB src1 src2));
   format %{ "vpaddb  $dst,$src1,$src2\t! add packed16B" %}
@@ -6143,7 +6195,7 @@ instruct vadd16B_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16B_mem(vecX dst, vecX src, memory mem) %{
+instruct vadd16B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 16);
   match(Set dst (AddVB src (LoadVector mem)));
   format %{ "vpaddb  $dst,$src,$mem\t! add packed16B" %}
@@ -6154,7 +6206,7 @@ instruct vadd16B_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd32B_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vadd32B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 32);
   match(Set dst (AddVB src1 src2));
   format %{ "vpaddb  $dst,$src1,$src2\t! add packed32B" %}
@@ -6165,7 +6217,7 @@ instruct vadd32B_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd32B_mem(vecY dst, vecY src, memory mem) %{
+instruct vadd32B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 32);
   match(Set dst (AddVB src (LoadVector mem)));
   format %{ "vpaddb  $dst,$src,$mem\t! add packed32B" %}
@@ -6176,7 +6228,7 @@ instruct vadd32B_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vadd64B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 64);
   match(Set dst (AddVB src1 src2));
   format %{ "vpaddb  $dst,$src1,$src2\t! add packed64B" %}
@@ -6187,7 +6239,7 @@ instruct vadd64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd64B_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vadd64B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 64);
   match(Set dst (AddVB src (LoadVector mem)));
   format %{ "vpaddb  $dst,$src,$mem\t! add packed64B" %}
@@ -6199,7 +6251,7 @@ instruct vadd64B_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Shorts/Chars vector add
-instruct vadd2S(vecS dst, vecS src) %{
+instruct vadd2S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVS dst src));
   format %{ "paddw   $dst,$src\t! add packed2S" %}
@@ -6209,7 +6261,7 @@ instruct vadd2S(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2S_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vadd2S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0  && n->as_Vector()->length() == 2);
   match(Set dst (AddVS src1 src2));
   format %{ "vpaddw  $dst,$src1,$src2\t! add packed2S" %}
@@ -6220,7 +6272,7 @@ instruct vadd2S_reg(vecS dst, vecS src1, vecS src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2S_mem(vecS dst, vecS src, memory mem) %{
+instruct vadd2S_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVS src (LoadVector mem)));
@@ -6232,7 +6284,7 @@ instruct vadd2S_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4S(vecD dst, vecD src) %{
+instruct vadd4S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVS dst src));
   format %{ "paddw   $dst,$src\t! add packed4S" %}
@@ -6242,7 +6294,7 @@ instruct vadd4S(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4S_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vadd4S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVS src1 src2));
   format %{ "vpaddw  $dst,$src1,$src2\t! add packed4S" %}
@@ -6253,7 +6305,7 @@ instruct vadd4S_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4S_mem(vecD dst, vecD src, memory mem) %{
+instruct vadd4S_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX == 0) && (n->as_Vector()->length() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVS src (LoadVector mem)));
@@ -6265,7 +6317,7 @@ instruct vadd4S_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8S(vecX dst, vecX src) %{
+instruct vadd8S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 8);
   match(Set dst (AddVS dst src));
   format %{ "paddw   $dst,$src\t! add packed8S" %}
@@ -6275,7 +6327,7 @@ instruct vadd8S(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8S_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vadd8S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (AddVS src1 src2));
   format %{ "vpaddw  $dst,$src1,$src2\t! add packed8S" %}
@@ -6286,7 +6338,7 @@ instruct vadd8S_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8S_mem(vecX dst, vecX src, memory mem) %{
+instruct vadd8S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (AddVS src (LoadVector mem)));
   format %{ "vpaddw  $dst,$src,$mem\t! add packed8S" %}
@@ -6297,7 +6349,7 @@ instruct vadd8S_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16S_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vadd16S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (AddVS src1 src2));
   format %{ "vpaddw  $dst,$src1,$src2\t! add packed16S" %}
@@ -6308,7 +6360,7 @@ instruct vadd16S_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16S_mem(vecY dst, vecY src, memory mem) %{
+instruct vadd16S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (AddVS src (LoadVector mem)));
   format %{ "vpaddw  $dst,$src,$mem\t! add packed16S" %}
@@ -6319,7 +6371,7 @@ instruct vadd16S_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd32S_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vadd32S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 32);
   match(Set dst (AddVS src1 src2));
   format %{ "vpaddw  $dst,$src1,$src2\t! add packed32S" %}
@@ -6330,7 +6382,7 @@ instruct vadd32S_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd32S_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vadd32S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 32);
   match(Set dst (AddVS src (LoadVector mem)));
   format %{ "vpaddw  $dst,$src,$mem\t! add packed32S" %}
@@ -6342,7 +6394,7 @@ instruct vadd32S_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Integers vector add
-instruct vadd2I(vecD dst, vecD src) %{
+instruct vadd2I(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVI dst src));
   format %{ "paddd   $dst,$src\t! add packed2I" %}
@@ -6352,7 +6404,7 @@ instruct vadd2I(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2I_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vadd2I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVI src1 src2));
   format %{ "vpaddd  $dst,$src1,$src2\t! add packed2I" %}
@@ -6363,7 +6415,7 @@ instruct vadd2I_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2I_mem(vecD dst, vecD src, memory mem) %{
+instruct vadd2I_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVI src (LoadVector mem)));
@@ -6375,7 +6427,7 @@ instruct vadd2I_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4I(vecX dst, vecX src) %{
+instruct vadd4I(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVI dst src));
   format %{ "paddd   $dst,$src\t! add packed4I" %}
@@ -6385,7 +6437,7 @@ instruct vadd4I(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4I_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vadd4I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVI src1 src2));
   format %{ "vpaddd  $dst,$src1,$src2\t! add packed4I" %}
@@ -6396,7 +6448,7 @@ instruct vadd4I_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4I_mem(vecX dst, vecX src, memory mem) %{
+instruct vadd4I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVI src (LoadVector mem)));
   format %{ "vpaddd  $dst,$src,$mem\t! add packed4I" %}
@@ -6407,7 +6459,7 @@ instruct vadd4I_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8I_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vadd8I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 8);
   match(Set dst (AddVI src1 src2));
   format %{ "vpaddd  $dst,$src1,$src2\t! add packed8I" %}
@@ -6418,7 +6470,7 @@ instruct vadd8I_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8I_mem(vecY dst, vecY src, memory mem) %{
+instruct vadd8I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 8);
   match(Set dst (AddVI src (LoadVector mem)));
   format %{ "vpaddd  $dst,$src,$mem\t! add packed8I" %}
@@ -6429,7 +6481,7 @@ instruct vadd8I_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16I_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vadd16I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (AddVI src1 src2));
   format %{ "vpaddd  $dst,$src1,$src2\t! add packed16I" %}
@@ -6440,7 +6492,7 @@ instruct vadd16I_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16I_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vadd16I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (AddVI src (LoadVector mem)));
   format %{ "vpaddd  $dst,$src,$mem\t! add packed16I" %}
@@ -6452,7 +6504,7 @@ instruct vadd16I_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Longs vector add
-instruct vadd2L(vecX dst, vecX src) %{
+instruct vadd2L(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVL dst src));
   format %{ "paddq   $dst,$src\t! add packed2L" %}
@@ -6462,7 +6514,7 @@ instruct vadd2L(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2L_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vadd2L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVL src1 src2));
   format %{ "vpaddq  $dst,$src1,$src2\t! add packed2L" %}
@@ -6473,7 +6525,7 @@ instruct vadd2L_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2L_mem(vecX dst, vecX src, memory mem) %{
+instruct vadd2L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVL src (LoadVector mem)));
   format %{ "vpaddq  $dst,$src,$mem\t! add packed2L" %}
@@ -6484,7 +6536,7 @@ instruct vadd2L_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4L_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vadd4L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 4);
   match(Set dst (AddVL src1 src2));
   format %{ "vpaddq  $dst,$src1,$src2\t! add packed4L" %}
@@ -6495,7 +6547,7 @@ instruct vadd4L_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4L_mem(vecY dst, vecY src, memory mem) %{
+instruct vadd4L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 4);
   match(Set dst (AddVL src (LoadVector mem)));
   format %{ "vpaddq  $dst,$src,$mem\t! add packed4L" %}
@@ -6506,7 +6558,7 @@ instruct vadd4L_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8L_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vadd8L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AddVL src1 src2));
   format %{ "vpaddq  $dst,$src1,$src2\t! add packed8L" %}
@@ -6517,7 +6569,7 @@ instruct vadd8L_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8L_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vadd8L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AddVL src (LoadVector mem)));
   format %{ "vpaddq  $dst,$src,$mem\t! add packed8L" %}
@@ -6529,7 +6581,7 @@ instruct vadd8L_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Floats vector add
-instruct vadd2F(vecD dst, vecD src) %{
+instruct vadd2F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVF dst src));
   format %{ "addps   $dst,$src\t! add packed2F" %}
@@ -6539,7 +6591,7 @@ instruct vadd2F(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2F_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vadd2F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVF src1 src2));
   format %{ "vaddps  $dst,$src1,$src2\t! add packed2F" %}
@@ -6550,7 +6602,7 @@ instruct vadd2F_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2F_mem(vecD dst, vecD src, memory mem) %{
+instruct vadd2F_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX == 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVF src (LoadVector mem)));
@@ -6562,7 +6614,7 @@ instruct vadd2F_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4F(vecX dst, vecX src) %{
+instruct vadd4F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVF dst src));
   format %{ "addps   $dst,$src\t! add packed4F" %}
@@ -6572,7 +6624,7 @@ instruct vadd4F(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4F_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vadd4F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVF src1 src2));
   format %{ "vaddps  $dst,$src1,$src2\t! add packed4F" %}
@@ -6583,7 +6635,7 @@ instruct vadd4F_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4F_mem(vecX dst, vecX src, memory mem) %{
+instruct vadd4F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVF src (LoadVector mem)));
   format %{ "vaddps  $dst,$src,$mem\t! add packed4F" %}
@@ -6594,7 +6646,7 @@ instruct vadd4F_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8F_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vadd8F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (AddVF src1 src2));
   format %{ "vaddps  $dst,$src1,$src2\t! add packed8F" %}
@@ -6605,7 +6657,7 @@ instruct vadd8F_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8F_mem(vecY dst, vecY src, memory mem) %{
+instruct vadd8F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (AddVF src (LoadVector mem)));
   format %{ "vaddps  $dst,$src,$mem\t! add packed8F" %}
@@ -6616,7 +6668,7 @@ instruct vadd8F_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vadd16F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (AddVF src1 src2));
   format %{ "vaddps  $dst,$src1,$src2\t! add packed16F" %}
@@ -6627,7 +6679,7 @@ instruct vadd16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd16F_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vadd16F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (AddVF src (LoadVector mem)));
   format %{ "vaddps  $dst,$src,$mem\t! add packed16F" %}
@@ -6639,7 +6691,7 @@ instruct vadd16F_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Doubles vector add
-instruct vadd2D(vecX dst, vecX src) %{
+instruct vadd2D(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVD dst src));
   format %{ "addpd   $dst,$src\t! add packed2D" %}
@@ -6649,7 +6701,7 @@ instruct vadd2D(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2D_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vadd2D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVD src1 src2));
   format %{ "vaddpd  $dst,$src1,$src2\t! add packed2D" %}
@@ -6660,7 +6712,7 @@ instruct vadd2D_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd2D_mem(vecX dst, vecX src, memory mem) %{
+instruct vadd2D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (AddVD src (LoadVector mem)));
   format %{ "vaddpd  $dst,$src,$mem\t! add packed2D" %}
@@ -6671,7 +6723,7 @@ instruct vadd2D_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4D_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vadd4D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVD src1 src2));
   format %{ "vaddpd  $dst,$src1,$src2\t! add packed4D" %}
@@ -6682,7 +6734,7 @@ instruct vadd4D_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd4D_mem(vecY dst, vecY src, memory mem) %{
+instruct vadd4D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AddVD src (LoadVector mem)));
   format %{ "vaddpd  $dst,$src,$mem\t! add packed4D" %}
@@ -6693,7 +6745,7 @@ instruct vadd4D_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vadd8D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AddVD src1 src2));
   format %{ "vaddpd  $dst,$src1,$src2\t! add packed8D" %}
@@ -6704,7 +6756,7 @@ instruct vadd8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vadd8D_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vadd8D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AddVD src (LoadVector mem)));
   format %{ "vaddpd  $dst,$src,$mem\t! add packed8D" %}
@@ -6718,7 +6770,7 @@ instruct vadd8D_mem(vecZ dst, vecZ src, memory mem) %{
 // --------------------------------- SUB --------------------------------------
 
 // Bytes vector sub
-instruct vsub4B(vecS dst, vecS src) %{
+instruct vsub4B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVB dst src));
   format %{ "psubb   $dst,$src\t! sub packed4B" %}
@@ -6728,7 +6780,7 @@ instruct vsub4B(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4B_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vsub4B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVB src1 src2));
   format %{ "vpsubb  $dst,$src1,$src2\t! sub packed4B" %}
@@ -6739,7 +6791,7 @@ instruct vsub4B_reg(vecS dst, vecS src1, vecS src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4B_mem(vecS dst, vecS src, memory mem) %{
+instruct vsub4B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX == 0) && (n->as_Vector()->length() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVB src (LoadVector mem)));
@@ -6751,7 +6803,7 @@ instruct vsub4B_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8B(vecD dst, vecD src) %{
+instruct vsub8B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 8);
   match(Set dst (SubVB dst src));
   format %{ "psubb   $dst,$src\t! sub packed8B" %}
@@ -6761,7 +6813,7 @@ instruct vsub8B(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8B_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vsub8B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (SubVB src1 src2));
   format %{ "vpsubb  $dst,$src1,$src2\t! sub packed8B" %}
@@ -6772,7 +6824,7 @@ instruct vsub8B_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8B_mem(vecD dst, vecD src, memory mem) %{
+instruct vsub8B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 8) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVB src (LoadVector mem)));
@@ -6784,7 +6836,7 @@ instruct vsub8B_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16B(vecX dst, vecX src) %{
+instruct vsub16B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 16);
   match(Set dst (SubVB dst src));
   format %{ "psubb   $dst,$src\t! sub packed16B" %}
@@ -6794,7 +6846,7 @@ instruct vsub16B(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16B_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vsub16B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 16);
   match(Set dst (SubVB src1 src2));
   format %{ "vpsubb  $dst,$src1,$src2\t! sub packed16B" %}
@@ -6805,7 +6857,7 @@ instruct vsub16B_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16B_mem(vecX dst, vecX src, memory mem) %{
+instruct vsub16B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 16);
   match(Set dst (SubVB src (LoadVector mem)));
   format %{ "vpsubb  $dst,$src,$mem\t! sub packed16B" %}
@@ -6816,7 +6868,7 @@ instruct vsub16B_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub32B_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vsub32B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 32);
   match(Set dst (SubVB src1 src2));
   format %{ "vpsubb  $dst,$src1,$src2\t! sub packed32B" %}
@@ -6827,7 +6879,7 @@ instruct vsub32B_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub32B_mem(vecY dst, vecY src, memory mem) %{
+instruct vsub32B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 32);
   match(Set dst (SubVB src (LoadVector mem)));
   format %{ "vpsubb  $dst,$src,$mem\t! sub packed32B" %}
@@ -6838,7 +6890,7 @@ instruct vsub32B_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vsub64B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 64);
   match(Set dst (SubVB src1 src2));
   format %{ "vpsubb  $dst,$src1,$src2\t! sub packed64B" %}
@@ -6849,7 +6901,7 @@ instruct vsub64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub64B_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vsub64B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 64);
   match(Set dst (SubVB src (LoadVector mem)));
   format %{ "vpsubb  $dst,$src,$mem\t! sub packed64B" %}
@@ -6861,7 +6913,7 @@ instruct vsub64B_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Shorts/Chars vector sub
-instruct vsub2S(vecS dst, vecS src) %{
+instruct vsub2S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVS dst src));
   format %{ "psubw   $dst,$src\t! sub packed2S" %}
@@ -6871,7 +6923,7 @@ instruct vsub2S(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2S_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vsub2S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVS src1 src2));
   format %{ "vpsubw  $dst,$src1,$src2\t! sub packed2S" %}
@@ -6882,7 +6934,7 @@ instruct vsub2S_reg(vecS dst, vecS src1, vecS src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2S_mem(vecS dst, vecS src, memory mem) %{
+instruct vsub2S_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX == 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVS src (LoadVector mem)));
@@ -6894,7 +6946,7 @@ instruct vsub2S_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4S(vecD dst, vecD src) %{
+instruct vsub4S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVS dst src));
   format %{ "psubw   $dst,$src\t! sub packed4S" %}
@@ -6904,7 +6956,7 @@ instruct vsub4S(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4S_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vsub4S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVS src1 src2));
   format %{ "vpsubw  $dst,$src1,$src2\t! sub packed4S" %}
@@ -6915,7 +6967,7 @@ instruct vsub4S_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4S_mem(vecD dst, vecD src, memory mem) %{
+instruct vsub4S_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVS src (LoadVector mem)));
@@ -6927,7 +6979,7 @@ instruct vsub4S_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8S(vecX dst, vecX src) %{
+instruct vsub8S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 8);
   match(Set dst (SubVS dst src));
   format %{ "psubw   $dst,$src\t! sub packed8S" %}
@@ -6937,7 +6989,7 @@ instruct vsub8S(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8S_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vsub8S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (SubVS src1 src2));
   format %{ "vpsubw  $dst,$src1,$src2\t! sub packed8S" %}
@@ -6948,7 +7000,7 @@ instruct vsub8S_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8S_mem(vecX dst, vecX src, memory mem) %{
+instruct vsub8S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (SubVS src (LoadVector mem)));
   format %{ "vpsubw  $dst,$src,$mem\t! sub packed8S" %}
@@ -6959,7 +7011,7 @@ instruct vsub8S_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16S_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vsub16S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (SubVS src1 src2));
   format %{ "vpsubw  $dst,$src1,$src2\t! sub packed16S" %}
@@ -6970,7 +7022,7 @@ instruct vsub16S_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16S_mem(vecY dst, vecY src, memory mem) %{
+instruct vsub16S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (SubVS src (LoadVector mem)));
   format %{ "vpsubw  $dst,$src,$mem\t! sub packed16S" %}
@@ -6981,7 +7033,7 @@ instruct vsub16S_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub32S_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vsub32S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 32);
   match(Set dst (SubVS src1 src2));
   format %{ "vpsubw  $dst,$src1,$src2\t! sub packed32S" %}
@@ -6992,7 +7044,7 @@ instruct vsub32S_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub32S_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vsub32S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 32);
   match(Set dst (SubVS src (LoadVector mem)));
   format %{ "vpsubw  $dst,$src,$mem\t! sub packed32S" %}
@@ -7004,7 +7056,7 @@ instruct vsub32S_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Integers vector sub
-instruct vsub2I(vecD dst, vecD src) %{
+instruct vsub2I(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVI dst src));
   format %{ "psubd   $dst,$src\t! sub packed2I" %}
@@ -7014,7 +7066,7 @@ instruct vsub2I(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2I_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vsub2I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVI src1 src2));
   format %{ "vpsubd  $dst,$src1,$src2\t! sub packed2I" %}
@@ -7025,7 +7077,7 @@ instruct vsub2I_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2I_mem(vecD dst, vecD src, memory mem) %{
+instruct vsub2I_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVI src (LoadVector mem)));
@@ -7037,7 +7089,7 @@ instruct vsub2I_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4I(vecX dst, vecX src) %{
+instruct vsub4I(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVI dst src));
   format %{ "psubd   $dst,$src\t! sub packed4I" %}
@@ -7047,7 +7099,7 @@ instruct vsub4I(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4I_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vsub4I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVI src1 src2));
   format %{ "vpsubd  $dst,$src1,$src2\t! sub packed4I" %}
@@ -7058,7 +7110,7 @@ instruct vsub4I_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4I_mem(vecX dst, vecX src, memory mem) %{
+instruct vsub4I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVI src (LoadVector mem)));
   format %{ "vpsubd  $dst,$src,$mem\t! sub packed4I" %}
@@ -7069,7 +7121,7 @@ instruct vsub4I_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8I_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vsub8I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 8);
   match(Set dst (SubVI src1 src2));
   format %{ "vpsubd  $dst,$src1,$src2\t! sub packed8I" %}
@@ -7080,7 +7132,7 @@ instruct vsub8I_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8I_mem(vecY dst, vecY src, memory mem) %{
+instruct vsub8I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 8);
   match(Set dst (SubVI src (LoadVector mem)));
   format %{ "vpsubd  $dst,$src,$mem\t! sub packed8I" %}
@@ -7091,7 +7143,7 @@ instruct vsub8I_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16I_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vsub16I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (SubVI src1 src2));
   format %{ "vpsubd  $dst,$src1,$src2\t! sub packed16I" %}
@@ -7102,7 +7154,7 @@ instruct vsub16I_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16I_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vsub16I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (SubVI src (LoadVector mem)));
   format %{ "vpsubd  $dst,$src,$mem\t! sub packed16I" %}
@@ -7114,7 +7166,7 @@ instruct vsub16I_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Longs vector sub
-instruct vsub2L(vecX dst, vecX src) %{
+instruct vsub2L(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVL dst src));
   format %{ "psubq   $dst,$src\t! sub packed2L" %}
@@ -7124,7 +7176,7 @@ instruct vsub2L(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2L_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vsub2L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVL src1 src2));
   format %{ "vpsubq  $dst,$src1,$src2\t! sub packed2L" %}
@@ -7135,7 +7187,7 @@ instruct vsub2L_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2L_mem(vecX dst, vecX src, memory mem) %{
+instruct vsub2L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVL src (LoadVector mem)));
   format %{ "vpsubq  $dst,$src,$mem\t! sub packed2L" %}
@@ -7146,7 +7198,7 @@ instruct vsub2L_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4L_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vsub4L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 4);
   match(Set dst (SubVL src1 src2));
   format %{ "vpsubq  $dst,$src1,$src2\t! sub packed4L" %}
@@ -7157,7 +7209,7 @@ instruct vsub4L_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4L_mem(vecY dst, vecY src, memory mem) %{
+instruct vsub4L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 4);
   match(Set dst (SubVL src (LoadVector mem)));
   format %{ "vpsubq  $dst,$src,$mem\t! sub packed4L" %}
@@ -7168,7 +7220,7 @@ instruct vsub4L_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8L_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vsub8L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (SubVL src1 src2));
   format %{ "vpsubq  $dst,$src1,$src2\t! sub packed8L" %}
@@ -7179,7 +7231,7 @@ instruct vsub8L_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8L_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vsub8L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (SubVL src (LoadVector mem)));
   format %{ "vpsubq  $dst,$src,$mem\t! sub packed8L" %}
@@ -7191,7 +7243,7 @@ instruct vsub8L_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Floats vector sub
-instruct vsub2F(vecD dst, vecD src) %{
+instruct vsub2F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVF dst src));
   format %{ "subps   $dst,$src\t! sub packed2F" %}
@@ -7201,7 +7253,7 @@ instruct vsub2F(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2F_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vsub2F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVF src1 src2));
   format %{ "vsubps  $dst,$src1,$src2\t! sub packed2F" %}
@@ -7212,7 +7264,7 @@ instruct vsub2F_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2F_mem(vecD dst, vecD src, memory mem) %{
+instruct vsub2F_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX == 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVF src (LoadVector mem)));
@@ -7224,7 +7276,7 @@ instruct vsub2F_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4F(vecX dst, vecX src) %{
+instruct vsub4F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVF dst src));
   format %{ "subps   $dst,$src\t! sub packed4F" %}
@@ -7234,7 +7286,7 @@ instruct vsub4F(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4F_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vsub4F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVF src1 src2));
   format %{ "vsubps  $dst,$src1,$src2\t! sub packed4F" %}
@@ -7245,7 +7297,7 @@ instruct vsub4F_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4F_mem(vecX dst, vecX src, memory mem) %{
+instruct vsub4F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVF src (LoadVector mem)));
   format %{ "vsubps  $dst,$src,$mem\t! sub packed4F" %}
@@ -7256,7 +7308,7 @@ instruct vsub4F_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8F_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vsub8F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (SubVF src1 src2));
   format %{ "vsubps  $dst,$src1,$src2\t! sub packed8F" %}
@@ -7267,7 +7319,7 @@ instruct vsub8F_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8F_mem(vecY dst, vecY src, memory mem) %{
+instruct vsub8F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (SubVF src (LoadVector mem)));
   format %{ "vsubps  $dst,$src,$mem\t! sub packed8F" %}
@@ -7278,7 +7330,7 @@ instruct vsub8F_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vsub16F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (SubVF src1 src2));
   format %{ "vsubps  $dst,$src1,$src2\t! sub packed16F" %}
@@ -7289,7 +7341,7 @@ instruct vsub16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub16F_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vsub16F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (SubVF src (LoadVector mem)));
   format %{ "vsubps  $dst,$src,$mem\t! sub packed16F" %}
@@ -7301,7 +7353,7 @@ instruct vsub16F_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Doubles vector sub
-instruct vsub2D(vecX dst, vecX src) %{
+instruct vsub2D(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVD dst src));
   format %{ "subpd   $dst,$src\t! sub packed2D" %}
@@ -7311,7 +7363,7 @@ instruct vsub2D(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2D_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vsub2D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVD src1 src2));
   format %{ "vsubpd  $dst,$src1,$src2\t! sub packed2D" %}
@@ -7322,7 +7374,7 @@ instruct vsub2D_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub2D_mem(vecX dst, vecX src, memory mem) %{
+instruct vsub2D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SubVD src (LoadVector mem)));
   format %{ "vsubpd  $dst,$src,$mem\t! sub packed2D" %}
@@ -7333,7 +7385,7 @@ instruct vsub2D_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4D_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vsub4D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVD src1 src2));
   format %{ "vsubpd  $dst,$src1,$src2\t! sub packed4D" %}
@@ -7344,7 +7396,7 @@ instruct vsub4D_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub4D_mem(vecY dst, vecY src, memory mem) %{
+instruct vsub4D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SubVD src (LoadVector mem)));
   format %{ "vsubpd  $dst,$src,$mem\t! sub packed4D" %}
@@ -7355,7 +7407,7 @@ instruct vsub4D_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vsub8D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (SubVD src1 src2));
   format %{ "vsubpd  $dst,$src1,$src2\t! sub packed8D" %}
@@ -7366,7 +7418,7 @@ instruct vsub8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsub8D_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vsub8D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (SubVD src (LoadVector mem)));
   format %{ "vsubpd  $dst,$src,$mem\t! sub packed8D" %}
@@ -7380,7 +7432,7 @@ instruct vsub8D_mem(vecZ dst, vecZ src, memory mem) %{
 // --------------------------------- MUL --------------------------------------
 
 // Byte vector mul
-instruct mul4B_reg(vecS dst, vecS src1, vecS src2, vecS tmp, rRegI scratch) %{
+instruct mul4B_reg(vec dst, vec src1, vec src2, vec tmp, rRegI scratch) %{
   predicate(UseSSE > 3 && n->as_Vector()->length() == 4);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp, TEMP scratch);
@@ -7401,7 +7453,7 @@ instruct mul4B_reg(vecS dst, vecS src1, vecS src2, vecS tmp, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct mul8B_reg(vecD dst, vecD src1, vecD src2, vecD tmp, rRegI scratch) %{
+instruct mul8B_reg(vec dst, vec src1, vec src2, vec tmp, rRegI scratch) %{
   predicate(UseSSE > 3 && n->as_Vector()->length() == 8);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp, TEMP scratch);
@@ -7422,7 +7474,7 @@ instruct mul8B_reg(vecD dst, vecD src1, vecD src2, vecD tmp, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct mul16B_reg(vecX dst, vecX src1, vecX src2, vecX tmp1, vecX tmp2, rRegI scratch) %{
+instruct mul16B_reg(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI scratch) %{
   predicate(UseSSE > 3 && n->as_Vector()->length() == 16);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP scratch);
@@ -7455,7 +7507,7 @@ instruct mul16B_reg(vecX dst, vecX src1, vecX src2, vecX tmp1, vecX tmp2, rRegI 
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul16B_reg_avx(vecX dst, vecX src1, vecX src2, vecX tmp, rRegI scratch) %{
+instruct vmul16B_reg_avx(vec dst, vec src1, vec src2, vec tmp, rRegI scratch) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp, TEMP scratch);
@@ -7479,7 +7531,7 @@ instruct vmul16B_reg_avx(vecX dst, vecX src1, vecX src2, vecX tmp, rRegI scratch
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul32B_reg_avx(vecY dst, vecY src1, vecY src2, vecY tmp1, vecY tmp2, rRegI scratch) %{
+instruct vmul32B_reg_avx(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI scratch) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 32);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP scratch);
@@ -7517,7 +7569,7 @@ instruct vmul32B_reg_avx(vecY dst, vecY src1, vecY src2, vecY tmp1, vecY tmp2, r
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul64B_reg_avx(vecZ dst, vecZ src1, vecZ src2, vecZ tmp1, vecZ tmp2, rRegI scratch) %{
+instruct vmul64B_reg_avx(vec dst, vec src1, vec src2, vec tmp1, vec tmp2, rRegI scratch) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 64);
   match(Set dst (MulVB src1 src2));
   effect(TEMP dst, TEMP tmp1, TEMP tmp2, TEMP scratch);
@@ -7560,7 +7612,7 @@ instruct vmul64B_reg_avx(vecZ dst, vecZ src1, vecZ src2, vecZ tmp1, vecZ tmp2, r
 %}
 
 // Shorts/Chars vector mul
-instruct vmul2S(vecS dst, vecS src) %{
+instruct vmul2S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVS dst src));
   format %{ "pmullw $dst,$src\t! mul packed2S" %}
@@ -7570,7 +7622,7 @@ instruct vmul2S(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2S_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vmul2S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVS src1 src2));
   format %{ "vpmullw $dst,$src1,$src2\t! mul packed2S" %}
@@ -7581,7 +7633,7 @@ instruct vmul2S_reg(vecS dst, vecS src1, vecS src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2S_mem(vecS dst, vecS src, memory mem) %{
+instruct vmul2S_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVS src (LoadVector mem)));
@@ -7593,7 +7645,7 @@ instruct vmul2S_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4S(vecD dst, vecD src) %{
+instruct vmul4S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVS dst src));
   format %{ "pmullw  $dst,$src\t! mul packed4S" %}
@@ -7603,7 +7655,7 @@ instruct vmul4S(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4S_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vmul4S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVS src1 src2));
   format %{ "vpmullw $dst,$src1,$src2\t! mul packed4S" %}
@@ -7614,7 +7666,7 @@ instruct vmul4S_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4S_mem(vecD dst, vecD src, memory mem) %{
+instruct vmul4S_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVS src (LoadVector mem)));
@@ -7626,7 +7678,7 @@ instruct vmul4S_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8S(vecX dst, vecX src) %{
+instruct vmul8S(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 8);
   match(Set dst (MulVS dst src));
   format %{ "pmullw  $dst,$src\t! mul packed8S" %}
@@ -7636,7 +7688,7 @@ instruct vmul8S(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8S_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vmul8S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (MulVS src1 src2));
   format %{ "vpmullw $dst,$src1,$src2\t! mul packed8S" %}
@@ -7647,7 +7699,7 @@ instruct vmul8S_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8S_mem(vecX dst, vecX src, memory mem) %{
+instruct vmul8S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (MulVS src (LoadVector mem)));
   format %{ "vpmullw $dst,$src,$mem\t! mul packed8S" %}
@@ -7658,7 +7710,7 @@ instruct vmul8S_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul16S_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vmul16S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (MulVS src1 src2));
   format %{ "vpmullw $dst,$src1,$src2\t! mul packed16S" %}
@@ -7669,7 +7721,7 @@ instruct vmul16S_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul16S_mem(vecY dst, vecY src, memory mem) %{
+instruct vmul16S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (MulVS src (LoadVector mem)));
   format %{ "vpmullw $dst,$src,$mem\t! mul packed16S" %}
@@ -7680,7 +7732,7 @@ instruct vmul16S_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul32S_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vmul32S_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 32);
   match(Set dst (MulVS src1 src2));
   format %{ "vpmullw $dst,$src1,$src2\t! mul packed32S" %}
@@ -7691,7 +7743,7 @@ instruct vmul32S_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul32S_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vmul32S_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 32);
   match(Set dst (MulVS src (LoadVector mem)));
   format %{ "vpmullw $dst,$src,$mem\t! mul packed32S" %}
@@ -7703,7 +7755,7 @@ instruct vmul32S_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Integers vector mul (sse4_1)
-instruct vmul2I(vecD dst, vecD src) %{
+instruct vmul2I(vec dst, vec src) %{
   predicate(UseSSE > 3 && n->as_Vector()->length() == 2);
   match(Set dst (MulVI dst src));
   format %{ "pmulld  $dst,$src\t! mul packed2I" %}
@@ -7713,7 +7765,7 @@ instruct vmul2I(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2I_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vmul2I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVI src1 src2));
   format %{ "vpmulld $dst,$src1,$src2\t! mul packed2I" %}
@@ -7724,7 +7776,7 @@ instruct vmul2I_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2I_mem(vecD dst, vecD src, memory mem) %{
+instruct vmul2I_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVI src (LoadVector mem)));
@@ -7736,7 +7788,7 @@ instruct vmul2I_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4I(vecX dst, vecX src) %{
+instruct vmul4I(vec dst, vec src) %{
   predicate(UseSSE > 3 && n->as_Vector()->length() == 4);
   match(Set dst (MulVI dst src));
   format %{ "pmulld  $dst,$src\t! mul packed4I" %}
@@ -7746,7 +7798,7 @@ instruct vmul4I(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4I_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vmul4I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVI src1 src2));
   format %{ "vpmulld $dst,$src1,$src2\t! mul packed4I" %}
@@ -7757,7 +7809,7 @@ instruct vmul4I_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4I_mem(vecX dst, vecX src, memory mem) %{
+instruct vmul4I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVI src (LoadVector mem)));
   format %{ "vpmulld $dst,$src,$mem\t! mul packed4I" %}
@@ -7768,7 +7820,7 @@ instruct vmul4I_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2L_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vmul2L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 2 && VM_Version::supports_avx512dq());
   match(Set dst (MulVL src1 src2));
   format %{ "vpmullq $dst,$src1,$src2\t! mul packed2L" %}
@@ -7779,7 +7831,7 @@ instruct vmul2L_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2L_mem(vecX dst, vecX src, memory mem) %{
+instruct vmul2L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 2 && VM_Version::supports_avx512dq());
   match(Set dst (MulVL src (LoadVector mem)));
   format %{ "vpmullq $dst,$src,$mem\t! mul packed2L" %}
@@ -7790,7 +7842,7 @@ instruct vmul2L_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4L_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vmul4L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 4 && VM_Version::supports_avx512dq());
   match(Set dst (MulVL src1 src2));
   format %{ "vpmullq $dst,$src1,$src2\t! mul packed4L" %}
@@ -7801,7 +7853,7 @@ instruct vmul4L_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4L_mem(vecY dst, vecY src, memory mem) %{
+instruct vmul4L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 4 && VM_Version::supports_avx512dq());
   match(Set dst (MulVL src (LoadVector mem)));
   format %{ "vpmullq $dst,$src,$mem\t! mul packed4L" %}
@@ -7812,7 +7864,7 @@ instruct vmul4L_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8L_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vmul8L_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8 && VM_Version::supports_avx512dq());
   match(Set dst (MulVL src1 src2));
   format %{ "vpmullq $dst,$src1,$src2\t! mul packed8L" %}
@@ -7823,7 +7875,7 @@ instruct vmul8L_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8L_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vmul8L_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8 && VM_Version::supports_avx512dq());
   match(Set dst (MulVL src (LoadVector mem)));
   format %{ "vpmullq $dst,$src,$mem\t! mul packed8L" %}
@@ -7834,7 +7886,7 @@ instruct vmul8L_mem(vecZ dst, vecZ src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8I_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vmul8I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 8);
   match(Set dst (MulVI src1 src2));
   format %{ "vpmulld $dst,$src1,$src2\t! mul packed8I" %}
@@ -7845,7 +7897,7 @@ instruct vmul8I_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8I_mem(vecY dst, vecY src, memory mem) %{
+instruct vmul8I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 8);
   match(Set dst (MulVI src (LoadVector mem)));
   format %{ "vpmulld $dst,$src,$mem\t! mul packed8I" %}
@@ -7856,7 +7908,7 @@ instruct vmul8I_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul16I_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vmul16I_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (MulVI src1 src2));
   format %{ "vpmulld $dst,$src1,$src2\t! mul packed16I" %}
@@ -7867,7 +7919,7 @@ instruct vmul16I_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul16I_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vmul16I_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (MulVI src (LoadVector mem)));
   format %{ "vpmulld $dst,$src,$mem\t! mul packed16I" %}
@@ -7879,7 +7931,7 @@ instruct vmul16I_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Floats vector mul
-instruct vmul2F(vecD dst, vecD src) %{
+instruct vmul2F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVF dst src));
   format %{ "mulps   $dst,$src\t! mul packed2F" %}
@@ -7889,7 +7941,7 @@ instruct vmul2F(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2F_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vmul2F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVF src1 src2));
   format %{ "vmulps  $dst,$src1,$src2\t! mul packed2F" %}
@@ -7900,7 +7952,7 @@ instruct vmul2F_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2F_mem(vecD dst, vecD src, memory mem) %{
+instruct vmul2F_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVF src (LoadVector mem)));
@@ -7912,7 +7964,7 @@ instruct vmul2F_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4F(vecX dst, vecX src) %{
+instruct vmul4F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVF dst src));
   format %{ "mulps   $dst,$src\t! mul packed4F" %}
@@ -7922,7 +7974,7 @@ instruct vmul4F(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4F_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vmul4F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVF src1 src2));
   format %{ "vmulps  $dst,$src1,$src2\t! mul packed4F" %}
@@ -7933,7 +7985,7 @@ instruct vmul4F_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4F_mem(vecX dst, vecX src, memory mem) %{
+instruct vmul4F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVF src (LoadVector mem)));
   format %{ "vmulps  $dst,$src,$mem\t! mul packed4F" %}
@@ -7944,7 +7996,7 @@ instruct vmul4F_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8F_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vmul8F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (MulVF src1 src2));
   format %{ "vmulps  $dst,$src1,$src2\t! mul packed8F" %}
@@ -7955,7 +8007,7 @@ instruct vmul8F_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8F_mem(vecY dst, vecY src, memory mem) %{
+instruct vmul8F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (MulVF src (LoadVector mem)));
   format %{ "vmulps  $dst,$src,$mem\t! mul packed8F" %}
@@ -7966,7 +8018,7 @@ instruct vmul8F_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vmul16F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (MulVF src1 src2));
   format %{ "vmulps  $dst,$src1,$src2\t! mul packed16F" %}
@@ -7977,7 +8029,7 @@ instruct vmul16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul16F_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vmul16F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (MulVF src (LoadVector mem)));
   format %{ "vmulps  $dst,$src,$mem\t! mul packed16F" %}
@@ -7989,7 +8041,7 @@ instruct vmul16F_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Doubles vector mul
-instruct vmul2D(vecX dst, vecX src) %{
+instruct vmul2D(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVD dst src));
   format %{ "mulpd   $dst,$src\t! mul packed2D" %}
@@ -7999,7 +8051,7 @@ instruct vmul2D(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2D_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vmul2D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVD src1 src2));
   format %{ "vmulpd  $dst,$src1,$src2\t! mul packed2D" %}
@@ -8010,7 +8062,7 @@ instruct vmul2D_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul2D_mem(vecX dst, vecX src, memory mem) %{
+instruct vmul2D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (MulVD src (LoadVector mem)));
   format %{ "vmulpd  $dst,$src,$mem\t! mul packed2D" %}
@@ -8021,7 +8073,7 @@ instruct vmul2D_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4D_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vmul4D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVD src1 src2));
   format %{ "vmulpd  $dst,$src1,$src2\t! mul packed4D" %}
@@ -8032,7 +8084,7 @@ instruct vmul4D_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul4D_mem(vecY dst, vecY src, memory mem) %{
+instruct vmul4D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (MulVD src (LoadVector mem)));
   format %{ "vmulpd  $dst,$src,$mem\t! mul packed4D" %}
@@ -8043,7 +8095,7 @@ instruct vmul4D_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vmul8D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (MulVD src1 src2));
   format %{ "vmulpd  $dst k0,$src1,$src2\t! mul packed8D" %}
@@ -8054,7 +8106,7 @@ instruct vmul8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmul8D_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vmul8D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (MulVD src (LoadVector mem)));
   format %{ "vmulpd  $dst k0,$src,$mem\t! mul packed8D" %}
@@ -8065,7 +8117,7 @@ instruct vmul8D_mem(vecZ dst, vecZ src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vcmov8F_reg(legVecY dst, legVecY src1, legVecY src2, immI8 cop, cmpOp_vcmppd copnd) %{
+instruct vcmov8F_reg(legVec dst, legVec src1, legVec src2, immI8 cop, cmpOp_vcmppd copnd) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (CMoveVF (Binary copnd cop) (Binary src1 src2)));
   effect(TEMP dst, USE src1, USE src2);
@@ -8081,7 +8133,7 @@ instruct vcmov8F_reg(legVecY dst, legVecY src1, legVecY src2, immI8 cop, cmpOp_v
   ins_pipe( pipe_slow );
 %}
 
-instruct vcmov4D_reg(legVecY dst, legVecY src1, legVecY src2, immI8 cop, cmpOp_vcmppd copnd) %{
+instruct vcmov4D_reg(legVec dst, legVec src1, legVec src2, immI8 cop, cmpOp_vcmppd copnd) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (CMoveVD (Binary copnd cop) (Binary src1 src2)));
   effect(TEMP dst, USE src1, USE src2);
@@ -8100,7 +8152,7 @@ instruct vcmov4D_reg(legVecY dst, legVecY src1, legVecY src2, immI8 cop, cmpOp_v
 // --------------------------------- DIV --------------------------------------
 
 // Floats vector div
-instruct vdiv2F(vecD dst, vecD src) %{
+instruct vdiv2F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (DivVF dst src));
   format %{ "divps   $dst,$src\t! div packed2F" %}
@@ -8110,7 +8162,7 @@ instruct vdiv2F(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv2F_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vdiv2F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (DivVF src1 src2));
   format %{ "vdivps  $dst,$src1,$src2\t! div packed2F" %}
@@ -8121,7 +8173,7 @@ instruct vdiv2F_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv2F_mem(vecD dst, vecD src, memory mem) %{
+instruct vdiv2F_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (DivVF src (LoadVector mem)));
@@ -8133,7 +8185,7 @@ instruct vdiv2F_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv4F(vecX dst, vecX src) %{
+instruct vdiv4F(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 4);
   match(Set dst (DivVF dst src));
   format %{ "divps   $dst,$src\t! div packed4F" %}
@@ -8143,7 +8195,7 @@ instruct vdiv4F(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv4F_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vdiv4F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (DivVF src1 src2));
   format %{ "vdivps  $dst,$src1,$src2\t! div packed4F" %}
@@ -8154,7 +8206,7 @@ instruct vdiv4F_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv4F_mem(vecX dst, vecX src, memory mem) %{
+instruct vdiv4F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (DivVF src (LoadVector mem)));
   format %{ "vdivps  $dst,$src,$mem\t! div packed4F" %}
@@ -8165,7 +8217,7 @@ instruct vdiv4F_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv8F_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vdiv8F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (DivVF src1 src2));
   format %{ "vdivps  $dst,$src1,$src2\t! div packed8F" %}
@@ -8176,7 +8228,7 @@ instruct vdiv8F_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv8F_mem(vecY dst, vecY src, memory mem) %{
+instruct vdiv8F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (DivVF src (LoadVector mem)));
   format %{ "vdivps  $dst,$src,$mem\t! div packed8F" %}
@@ -8187,7 +8239,7 @@ instruct vdiv8F_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vdiv16F_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 16);
   match(Set dst (DivVF src1 src2));
   format %{ "vdivps  $dst,$src1,$src2\t! div packed16F" %}
@@ -8198,7 +8250,7 @@ instruct vdiv16F_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv16F_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vdiv16F_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 16);
   match(Set dst (DivVF src (LoadVector mem)));
   format %{ "vdivps  $dst,$src,$mem\t! div packed16F" %}
@@ -8210,7 +8262,7 @@ instruct vdiv16F_mem(vecZ dst, vecZ src, memory mem) %{
 %}
 
 // Doubles vector div
-instruct vdiv2D(vecX dst, vecX src) %{
+instruct vdiv2D(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length() == 2);
   match(Set dst (DivVD dst src));
   format %{ "divpd   $dst,$src\t! div packed2D" %}
@@ -8220,7 +8272,7 @@ instruct vdiv2D(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv2D_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vdiv2D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (DivVD src1 src2));
   format %{ "vdivpd  $dst,$src1,$src2\t! div packed2D" %}
@@ -8231,7 +8283,7 @@ instruct vdiv2D_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv2D_mem(vecX dst, vecX src, memory mem) %{
+instruct vdiv2D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (DivVD src (LoadVector mem)));
   format %{ "vdivpd  $dst,$src,$mem\t! div packed2D" %}
@@ -8242,7 +8294,7 @@ instruct vdiv2D_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv4D_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vdiv4D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (DivVD src1 src2));
   format %{ "vdivpd  $dst,$src1,$src2\t! div packed4D" %}
@@ -8253,7 +8305,7 @@ instruct vdiv4D_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv4D_mem(vecY dst, vecY src, memory mem) %{
+instruct vdiv4D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (DivVD src (LoadVector mem)));
   format %{ "vdivpd  $dst,$src,$mem\t! div packed4D" %}
@@ -8264,7 +8316,7 @@ instruct vdiv4D_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vdiv8D_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (DivVD src1 src2));
   format %{ "vdivpd  $dst,$src1,$src2\t! div packed8D" %}
@@ -8275,7 +8327,7 @@ instruct vdiv8D_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vdiv8D_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vdiv8D_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (DivVD src (LoadVector mem)));
   format %{ "vdivpd  $dst,$src,$mem\t! div packed8D" %}
@@ -8289,7 +8341,7 @@ instruct vdiv8D_mem(vecZ dst, vecZ src, memory mem) %{
 // --------------------------------- Sqrt --------------------------------------
 
 // Floating point vector sqrt
-instruct vsqrt2D_reg(vecX dst, vecX src) %{
+instruct vsqrt2D_reg(vec dst, vec src) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SqrtVD src));
   format %{ "vsqrtpd  $dst,$src\t! sqrt packed2D" %}
@@ -8300,7 +8352,7 @@ instruct vsqrt2D_reg(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt2D_mem(vecX dst, memory mem) %{
+instruct vsqrt2D_mem(vec dst, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SqrtVD (LoadVector mem)));
   format %{ "vsqrtpd  $dst,$mem\t! sqrt packed2D" %}
@@ -8311,7 +8363,7 @@ instruct vsqrt2D_mem(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt4D_reg(vecY dst, vecY src) %{
+instruct vsqrt4D_reg(vec dst, vec src) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SqrtVD src));
   format %{ "vsqrtpd  $dst,$src\t! sqrt packed4D" %}
@@ -8322,7 +8374,7 @@ instruct vsqrt4D_reg(vecY dst, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt4D_mem(vecY dst, memory mem) %{
+instruct vsqrt4D_mem(vec dst, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SqrtVD (LoadVector mem)));
   format %{ "vsqrtpd  $dst,$mem\t! sqrt packed4D" %}
@@ -8333,7 +8385,7 @@ instruct vsqrt4D_mem(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt8D_reg(vecZ dst, vecZ src) %{
+instruct vsqrt8D_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (SqrtVD src));
   format %{ "vsqrtpd  $dst,$src\t! sqrt packed8D" %}
@@ -8344,7 +8396,7 @@ instruct vsqrt8D_reg(vecZ dst, vecZ src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt8D_mem(vecZ dst, memory mem) %{
+instruct vsqrt8D_mem(vec dst, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (SqrtVD (LoadVector mem)));
   format %{ "vsqrtpd  $dst,$mem\t! sqrt packed8D" %}
@@ -8355,7 +8407,7 @@ instruct vsqrt8D_mem(vecZ dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt2F_reg(vecD dst, vecD src) %{
+instruct vsqrt2F_reg(vec dst, vec src) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 2);
   match(Set dst (SqrtVF src));
   format %{ "vsqrtps  $dst,$src\t! sqrt packed2F" %}
@@ -8366,7 +8418,7 @@ instruct vsqrt2F_reg(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt2F_mem(vecD dst, memory mem) %{
+instruct vsqrt2F_mem(vec dst, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length() == 2) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SqrtVF (LoadVector mem)));
@@ -8378,7 +8430,7 @@ instruct vsqrt2F_mem(vecD dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt4F_reg(vecX dst, vecX src) %{
+instruct vsqrt4F_reg(vec dst, vec src) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SqrtVF src));
   format %{ "vsqrtps  $dst,$src\t! sqrt packed4F" %}
@@ -8389,7 +8441,7 @@ instruct vsqrt4F_reg(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt4F_mem(vecX dst, memory mem) %{
+instruct vsqrt4F_mem(vec dst, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (SqrtVF (LoadVector mem)));
   format %{ "vsqrtps  $dst,$mem\t! sqrt packed4F" %}
@@ -8400,7 +8452,7 @@ instruct vsqrt4F_mem(vecX dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt8F_reg(vecY dst, vecY src) %{
+instruct vsqrt8F_reg(vec dst, vec src) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (SqrtVF src));
   format %{ "vsqrtps  $dst,$src\t! sqrt packed8F" %}
@@ -8411,7 +8463,7 @@ instruct vsqrt8F_reg(vecY dst, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt8F_mem(vecY dst, memory mem) %{
+instruct vsqrt8F_mem(vec dst, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (SqrtVF (LoadVector mem)));
   format %{ "vsqrtps  $dst,$mem\t! sqrt packed8F" %}
@@ -8422,7 +8474,7 @@ instruct vsqrt8F_mem(vecY dst, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt16F_reg(vecZ dst, vecZ src) %{
+instruct vsqrt16F_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (SqrtVF src));
   format %{ "vsqrtps  $dst,$src\t! sqrt packed16F" %}
@@ -8433,7 +8485,7 @@ instruct vsqrt16F_reg(vecZ dst, vecZ src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsqrt16F_mem(vecZ dst, memory mem) %{
+instruct vsqrt16F_mem(vec dst, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (SqrtVF (LoadVector mem)));
   format %{ "vsqrtps  $dst,$mem\t! sqrt packed16F" %}
@@ -8448,7 +8500,7 @@ instruct vsqrt16F_mem(vecZ dst, memory mem) %{
 
 // Left and right shift count vectors are the same on x86
 // (only lowest bits of xmm reg are used for count).
-instruct vshiftcnt(vecS dst, rRegI cnt) %{
+instruct vshiftcnt(vec dst, rRegI cnt) %{
   match(Set dst (LShiftCntV cnt));
   match(Set dst (RShiftCntV cnt));
   format %{ "movdl    $dst,$cnt\t! load shift count" %}
@@ -8458,7 +8510,7 @@ instruct vshiftcnt(vecS dst, rRegI cnt) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshiftcntimm(vecS dst, immI8 cnt, rRegI tmp) %{
+instruct vshiftcntimm(vec dst, immI8 cnt, rRegI tmp) %{
   match(Set dst cnt);
   effect(TEMP tmp);
   format %{ "movl    $tmp,$cnt\t"
@@ -8471,7 +8523,7 @@ instruct vshiftcntimm(vecS dst, immI8 cnt, rRegI tmp) %{
 %}
 
 // Byte vector shift
-instruct vshift4B(vecS dst, vecS src, vecS shift, vecS tmp, rRegI scratch) %{
+instruct vshift4B(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
   predicate(UseSSE > 3 && n->as_Vector()->length() == 4);
   match(Set dst (LShiftVB src shift));
   match(Set dst (RShiftVB src shift));
@@ -8487,14 +8539,14 @@ instruct vshift4B(vecS dst, vecS src, vecS shift, vecS tmp, rRegI scratch) %{
 
     __ vextendbw(opcode, $tmp$$XMMRegister, $src$$XMMRegister);
     __ vshiftw(opcode, $tmp$$XMMRegister, $shift$$XMMRegister);
-    __ movdqu($dst$$XMMRegister, ExternalAddress(vector_short_to_byte_mask()), $scratch$$Register); 
+    __ movdqu($dst$$XMMRegister, ExternalAddress(vector_short_to_byte_mask()), $scratch$$Register);
     __ pand($dst$$XMMRegister, $tmp$$XMMRegister);
     __ packuswb($dst$$XMMRegister, $dst$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift8B(vecD dst, vecD src, vecS shift, vecD tmp, rRegI scratch) %{
+instruct vshift8B(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
   predicate(UseSSE > 3 && n->as_Vector()->length() == 8);
   match(Set dst (LShiftVB src shift));
   match(Set dst (RShiftVB src shift));
@@ -8510,14 +8562,14 @@ instruct vshift8B(vecD dst, vecD src, vecS shift, vecD tmp, rRegI scratch) %{
 
     __ vextendbw(opcode, $tmp$$XMMRegister, $src$$XMMRegister);
     __ vshiftw(opcode, $tmp$$XMMRegister, $shift$$XMMRegister);
-    __ movdqu($dst$$XMMRegister, ExternalAddress(vector_short_to_byte_mask()), $scratch$$Register); 
+    __ movdqu($dst$$XMMRegister, ExternalAddress(vector_short_to_byte_mask()), $scratch$$Register);
     __ pand($dst$$XMMRegister, $tmp$$XMMRegister);
     __ packuswb($dst$$XMMRegister, $dst$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift16B(vecX dst, vecX src, vecS shift, vecX tmp1, vecX tmp2, rRegI scratch) %{
+instruct vshift16B(vec dst, vec src, vec shift, vec tmp1, vec tmp2, rRegI scratch) %{
   predicate(UseSSE > 3  && UseAVX <= 1 && n->as_Vector()->length() == 16);
   match(Set dst (LShiftVB src shift));
   match(Set dst (RShiftVB src shift));
@@ -8548,7 +8600,7 @@ instruct vshift16B(vecX dst, vecX src, vecS shift, vecX tmp1, vecX tmp2, rRegI s
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift16B_avx(vecX dst, vecX src, vecS shift, vecX tmp, rRegI scratch) %{
+instruct vshift16B_avx(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (LShiftVB src shift));
   match(Set dst (RShiftVB src shift));
@@ -8572,7 +8624,7 @@ instruct vshift16B_avx(vecX dst, vecX src, vecS shift, vecX tmp, rRegI scratch) 
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift32B_avx(vecY dst, vecY src, vecS shift, vecY tmp, rRegI scratch) %{
+instruct vshift32B_avx(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 32);
   match(Set dst (LShiftVB src shift));
   match(Set dst (RShiftVB src shift));
@@ -8604,7 +8656,7 @@ instruct vshift32B_avx(vecY dst, vecY src, vecS shift, vecY tmp, rRegI scratch) 
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift64B_avx(vecZ dst, vecZ src, vecS shift, vecZ tmp1, vecZ tmp2, rRegI scratch) %{
+instruct vshift64B_avx(vec dst, vec src, vec shift, vec tmp1, vec tmp2, rRegI scratch) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 64);
   match(Set dst (LShiftVB src shift));
   match(Set dst (RShiftVB src shift));
@@ -8647,7 +8699,7 @@ instruct vshift64B_avx(vecZ dst, vecZ src, vecS shift, vecZ tmp1, vecZ tmp2, rRe
 // sign extension before a shift. But char vectors are fine since chars are
 // unsigned values.
 // Shorts/Chars vector left shift
-instruct vshist2S(vecS dst, vecS src, vecS shift) %{
+instruct vshist2S(vec dst, vec src, vec shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (LShiftVS src shift));
   match(Set dst (RShiftVS src shift));
@@ -8656,7 +8708,7 @@ instruct vshist2S(vecS dst, vecS src, vecS shift) %{
   format %{ "vshiftw  $dst,$src,$shift\t! shift packed2S" %}
   ins_encode %{
     int opcode = this->as_Mach()->ideal_Opcode();
-    if (UseAVX == 0) { 
+    if (UseAVX == 0) {
       if ($dst$$XMMRegister != $src$$XMMRegister)
          __ movflt($dst$$XMMRegister, $src$$XMMRegister);
       __ vshiftw(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
@@ -8668,7 +8720,7 @@ instruct vshist2S(vecS dst, vecS src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift4S(vecD dst, vecD src, vecS shift) %{
+instruct vshift4S(vec dst, vec src, vec shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (LShiftVS src shift));
   match(Set dst (RShiftVS src shift));
@@ -8677,11 +8729,11 @@ instruct vshift4S(vecD dst, vecD src, vecS shift) %{
   format %{ "vshiftw  $dst,$src,$shift\t! shift packed4S" %}
   ins_encode %{
     int opcode = this->as_Mach()->ideal_Opcode();
-    if (UseAVX == 0) { 
+    if (UseAVX == 0) {
       if ($dst$$XMMRegister != $src$$XMMRegister)
          __ movdbl($dst$$XMMRegister, $src$$XMMRegister);
       __ vshiftw(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
-    
+
     } else {
       int vector_len = 0;
       __ vshiftw(opcode, $dst$$XMMRegister, $src$$XMMRegister, $shift$$XMMRegister, vector_len);
@@ -8690,7 +8742,7 @@ instruct vshift4S(vecD dst, vecD src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift8S(vecX dst, vecX src, vecS shift) %{
+instruct vshift8S(vec dst, vec src, vec shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (LShiftVS src shift));
   match(Set dst (RShiftVS src shift));
@@ -8699,7 +8751,7 @@ instruct vshift8S(vecX dst, vecX src, vecS shift) %{
   format %{ "vshiftw  $dst,$src,$shift\t! shift packed8S" %}
   ins_encode %{
     int opcode = this->as_Mach()->ideal_Opcode();
-    if (UseAVX == 0) { 
+    if (UseAVX == 0) {
       if ($dst$$XMMRegister != $src$$XMMRegister)
          __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
       __ vshiftw(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
@@ -8711,7 +8763,7 @@ instruct vshift8S(vecX dst, vecX src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift16S(vecY dst, vecY src, vecS shift) %{
+instruct vshift16S(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (LShiftVS src shift));
   match(Set dst (RShiftVS src shift));
@@ -8726,7 +8778,7 @@ instruct vshift16S(vecY dst, vecY src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift32S(vecZ dst, vecZ src, vecS shift) %{
+instruct vshift32S(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 2 && VM_Version::supports_avx512bw() && n->as_Vector()->length() == 32);
   match(Set dst (LShiftVS src shift));
   match(Set dst (RShiftVS src shift));
@@ -8742,7 +8794,7 @@ instruct vshift32S(vecZ dst, vecZ src, vecS shift) %{
 %}
 
 // Integers vector left shift
-instruct vshift2I(vecD dst, vecD src, vecS shift) %{
+instruct vshift2I(vec dst, vec src, vec shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (LShiftVI src shift));
   match(Set dst (RShiftVI src shift));
@@ -8751,7 +8803,7 @@ instruct vshift2I(vecD dst, vecD src, vecS shift) %{
   format %{ "vshiftd  $dst,$src,$shift\t! shift packed2I" %}
   ins_encode %{
     int opcode = this->as_Mach()->ideal_Opcode();
-    if (UseAVX == 0) { 
+    if (UseAVX == 0) {
       if ($dst$$XMMRegister != $src$$XMMRegister)
          __ movdbl($dst$$XMMRegister, $src$$XMMRegister);
       __ vshiftd(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
@@ -8763,7 +8815,7 @@ instruct vshift2I(vecD dst, vecD src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift4I(vecX dst, vecX src, vecS shift) %{
+instruct vshift4I(vec dst, vec src, vec shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (LShiftVI src shift));
   match(Set dst (RShiftVI src shift));
@@ -8772,7 +8824,7 @@ instruct vshift4I(vecX dst, vecX src, vecS shift) %{
   format %{ "vshiftd  $dst,$src,$shift\t! shift packed4I" %}
   ins_encode %{
     int opcode = this->as_Mach()->ideal_Opcode();
-    if (UseAVX == 0) { 
+    if (UseAVX == 0) {
       if ($dst$$XMMRegister != $src$$XMMRegister)
          __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
       __ vshiftd(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
@@ -8784,7 +8836,7 @@ instruct vshift4I(vecX dst, vecX src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift8I(vecY dst, vecY src, vecS shift) %{
+instruct vshift8I(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 8);
   match(Set dst (LShiftVI src shift));
   match(Set dst (RShiftVI src shift));
@@ -8799,7 +8851,7 @@ instruct vshift8I(vecY dst, vecY src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift16I(vecZ dst, vecZ src, vecS shift) %{
+instruct vshift16I(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (LShiftVI src shift));
   match(Set dst (RShiftVI src shift));
@@ -8815,7 +8867,7 @@ instruct vshift16I(vecZ dst, vecZ src, vecS shift) %{
 %}
 
 // Longs vector shift
-instruct vshift2L(vecX dst, vecX src, vecS shift) %{
+instruct vshift2L(vec dst, vec src, vec shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (LShiftVL src shift));
   match(Set dst (URShiftVL src shift));
@@ -8823,7 +8875,7 @@ instruct vshift2L(vecX dst, vecX src, vecS shift) %{
   format %{ "vshiftq  $dst,$src,$shift\t! shift packed2L" %}
   ins_encode %{
     int opcode = this->as_Mach()->ideal_Opcode();
-    if (UseAVX == 0) { 
+    if (UseAVX == 0) {
       if ($dst$$XMMRegister != $src$$XMMRegister)
          __ movdqu($dst$$XMMRegister, $src$$XMMRegister);
       __ vshiftq(opcode, $dst$$XMMRegister, $shift$$XMMRegister);
@@ -8835,7 +8887,7 @@ instruct vshift2L(vecX dst, vecX src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift4L(vecY dst, vecY src, vecS shift) %{
+instruct vshift4L(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 4);
   match(Set dst (LShiftVL src shift));
   match(Set dst (URShiftVL src shift));
@@ -8849,7 +8901,7 @@ instruct vshift4L(vecY dst, vecY src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vshift8L(vecZ dst, vecZ src, vecS shift) %{
+instruct vshift8L(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (LShiftVL src shift));
   match(Set dst (RShiftVL src shift));
@@ -8866,7 +8918,7 @@ instruct vshift8L(vecZ dst, vecZ src, vecS shift) %{
 
 // -------------------ArithmeticRightShift -----------------------------------
 // Long vector arithmetic right shift
-instruct vsra2L_reg(vecX dst, vecX src, vecS shift, vecX tmp, rRegI scratch) %{
+instruct vsra2L_reg(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
   predicate(UseSSE >= 2 && n->as_Vector()->length() == 2);
   match(Set dst (RShiftVL src shift));
   effect(TEMP dst, TEMP tmp, TEMP scratch);
@@ -8887,7 +8939,7 @@ instruct vsra2L_reg(vecX dst, vecX src, vecS shift, vecX tmp, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsra2L_reg_evex(vecX dst, vecX src, vecS shift) %{
+instruct vsra2L_reg_evex(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 2);
   match(Set dst (RShiftVL src shift));
   format %{ "evpsraq  $dst,$src,$shift\t! arithmetic right shift packed2L" %}
@@ -8898,7 +8950,7 @@ instruct vsra2L_reg_evex(vecX dst, vecX src, vecS shift) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsra4L_reg(vecY dst, vecY src, vecS shift, vecY tmp, rRegI scratch) %{
+instruct vsra4L_reg(vec dst, vec src, vec shift, vec tmp, rRegI scratch) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 4);
   match(Set dst (RShiftVL src shift));
   effect(TEMP dst, TEMP tmp, TEMP scratch);
@@ -8918,7 +8970,7 @@ instruct vsra4L_reg(vecY dst, vecY src, vecS shift, vecY tmp, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vsra4L_reg_evex(vecY dst, vecY src, vecS shift) %{
+instruct vsra4L_reg_evex(vec dst, vec src, vec shift) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 4);
   match(Set dst (RShiftVL src shift));
   format %{ "evpsraq  $dst,$src,$shift\t! arithmetic right shift packed4L" %}
@@ -8931,7 +8983,7 @@ instruct vsra4L_reg_evex(vecY dst, vecY src, vecS shift) %{
 
 // --------------------------------- AND --------------------------------------
 
-instruct vand4B(vecS dst, vecS src) %{
+instruct vand4B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 4);
   match(Set dst (AndV dst src));
   format %{ "pand    $dst,$src\t! and vectors (4 bytes)" %}
@@ -8941,7 +8993,7 @@ instruct vand4B(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand4B_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vand4B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 4);
   match(Set dst (AndV src1 src2));
   format %{ "vpand   $dst,$src1,$src2\t! and vectors (4 bytes)" %}
@@ -8952,7 +9004,7 @@ instruct vand4B_reg(vecS dst, vecS src1, vecS src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand4B_mem(vecS dst, vecS src, memory mem) %{
+instruct vand4B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length_in_bytes() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AndV src (LoadVector mem)));
@@ -8964,7 +9016,7 @@ instruct vand4B_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand8B(vecD dst, vecD src) %{
+instruct vand8B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 8);
   match(Set dst (AndV dst src));
   format %{ "pand    $dst,$src\t! and vectors (8 bytes)" %}
@@ -8974,7 +9026,7 @@ instruct vand8B(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand8B_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vand8B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 8);
   match(Set dst (AndV src1 src2));
   format %{ "vpand   $dst,$src1,$src2\t! and vectors (8 bytes)" %}
@@ -8985,7 +9037,7 @@ instruct vand8B_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand8B_mem(vecD dst, vecD src, memory mem) %{
+instruct vand8B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length_in_bytes() == 8) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AndV src (LoadVector mem)));
@@ -8997,7 +9049,7 @@ instruct vand8B_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand16B(vecX dst, vecX src) %{
+instruct vand16B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (AndV dst src));
   format %{ "pand    $dst,$src\t! and vectors (16 bytes)" %}
@@ -9007,7 +9059,7 @@ instruct vand16B(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand16B_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vand16B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (AndV src1 src2));
   format %{ "vpand   $dst,$src1,$src2\t! and vectors (16 bytes)" %}
@@ -9018,7 +9070,7 @@ instruct vand16B_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand16B_mem(vecX dst, vecX src, memory mem) %{
+instruct vand16B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (AndV src (LoadVector mem)));
   format %{ "vpand   $dst,$src,$mem\t! and vectors (16 bytes)" %}
@@ -9029,7 +9081,7 @@ instruct vand16B_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand32B_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vand32B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length_in_bytes() == 32);
   match(Set dst (AndV src1 src2));
   format %{ "vpand   $dst,$src1,$src2\t! and vectors (32 bytes)" %}
@@ -9040,7 +9092,7 @@ instruct vand32B_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand32B_mem(vecY dst, vecY src, memory mem) %{
+instruct vand32B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length_in_bytes() == 32);
   match(Set dst (AndV src (LoadVector mem)));
   format %{ "vpand   $dst,$src,$mem\t! and vectors (32 bytes)" %}
@@ -9051,7 +9103,7 @@ instruct vand32B_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vand64B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length_in_bytes() == 64);
   match(Set dst (AndV src1 src2));
   format %{ "vpand   $dst,$src1,$src2\t! and vectors (64 bytes)" %}
@@ -9062,7 +9114,7 @@ instruct vand64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vand64B_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vand64B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length_in_bytes() == 64);
   match(Set dst (AndV src (LoadVector mem)));
   format %{ "vpand   $dst,$src,$mem\t! and vectors (64 bytes)" %}
@@ -9075,7 +9127,7 @@ instruct vand64B_mem(vecZ dst, vecZ src, memory mem) %{
 
 // --------------------------------- OR ---------------------------------------
 
-instruct vor4B(vecS dst, vecS src) %{
+instruct vor4B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 4);
   match(Set dst (OrV dst src));
   format %{ "por     $dst,$src\t! or vectors (4 bytes)" %}
@@ -9085,7 +9137,7 @@ instruct vor4B(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor4B_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vor4B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 4);
   match(Set dst (OrV src1 src2));
   format %{ "vpor    $dst,$src1,$src2\t! or vectors (4 bytes)" %}
@@ -9096,7 +9148,7 @@ instruct vor4B_reg(vecS dst, vecS src1, vecS src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor4B_mem(vecS dst, vecS src, memory mem) %{
+instruct vor4B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length_in_bytes() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (OrV src (LoadVector mem)));
@@ -9108,7 +9160,7 @@ instruct vor4B_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor8B(vecD dst, vecD src) %{
+instruct vor8B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 8);
   match(Set dst (OrV dst src));
   format %{ "por     $dst,$src\t! or vectors (8 bytes)" %}
@@ -9118,7 +9170,7 @@ instruct vor8B(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor8B_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vor8B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 8);
   match(Set dst (OrV src1 src2));
   format %{ "vpor    $dst,$src1,$src2\t! or vectors (8 bytes)" %}
@@ -9129,7 +9181,7 @@ instruct vor8B_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor8B_mem(vecD dst, vecD src, memory mem) %{
+instruct vor8B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length_in_bytes() == 8) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (OrV src (LoadVector mem)));
@@ -9141,7 +9193,7 @@ instruct vor8B_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor16B(vecX dst, vecX src) %{
+instruct vor16B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (OrV dst src));
   format %{ "por     $dst,$src\t! or vectors (16 bytes)" %}
@@ -9151,7 +9203,7 @@ instruct vor16B(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor16B_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vor16B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (OrV src1 src2));
   format %{ "vpor    $dst,$src1,$src2\t! or vectors (16 bytes)" %}
@@ -9162,7 +9214,7 @@ instruct vor16B_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor16B_mem(vecX dst, vecX src, memory mem) %{
+instruct vor16B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (OrV src (LoadVector mem)));
   format %{ "vpor    $dst,$src,$mem\t! or vectors (16 bytes)" %}
@@ -9173,7 +9225,7 @@ instruct vor16B_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor32B_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vor32B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length_in_bytes() == 32);
   match(Set dst (OrV src1 src2));
   format %{ "vpor    $dst,$src1,$src2\t! or vectors (32 bytes)" %}
@@ -9184,7 +9236,7 @@ instruct vor32B_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor32B_mem(vecY dst, vecY src, memory mem) %{
+instruct vor32B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length_in_bytes() == 32);
   match(Set dst (OrV src (LoadVector mem)));
   format %{ "vpor    $dst,$src,$mem\t! or vectors (32 bytes)" %}
@@ -9195,7 +9247,7 @@ instruct vor32B_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vor64B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length_in_bytes() == 64);
   match(Set dst (OrV src1 src2));
   format %{ "vpor    $dst,$src1,$src2\t! or vectors (64 bytes)" %}
@@ -9206,7 +9258,7 @@ instruct vor64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vor64B_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vor64B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length_in_bytes() == 64);
   match(Set dst (OrV src (LoadVector mem)));
   format %{ "vpor    $dst,$src,$mem\t! or vectors (64 bytes)" %}
@@ -9219,7 +9271,7 @@ instruct vor64B_mem(vecZ dst, vecZ src, memory mem) %{
 
 // --------------------------------- XOR --------------------------------------
 
-instruct vxor4B(vecS dst, vecS src) %{
+instruct vxor4B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 4);
   match(Set dst (XorV dst src));
   format %{ "pxor    $dst,$src\t! xor vectors (4 bytes)" %}
@@ -9229,7 +9281,7 @@ instruct vxor4B(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor4B_reg(vecS dst, vecS src1, vecS src2) %{
+instruct vxor4B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 4);
   match(Set dst (XorV src1 src2));
   format %{ "vpxor   $dst,$src1,$src2\t! xor vectors (4 bytes)" %}
@@ -9240,7 +9292,7 @@ instruct vxor4B_reg(vecS dst, vecS src1, vecS src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor4B_mem(vecS dst, vecS src, memory mem) %{
+instruct vxor4B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length_in_bytes() == 4) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (XorV src (LoadVector mem)));
@@ -9252,7 +9304,7 @@ instruct vxor4B_mem(vecS dst, vecS src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor8B(vecD dst, vecD src) %{
+instruct vxor8B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 8);
   match(Set dst (XorV dst src));
   format %{ "pxor    $dst,$src\t! xor vectors (8 bytes)" %}
@@ -9262,7 +9314,7 @@ instruct vxor8B(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor8B_reg(vecD dst, vecD src1, vecD src2) %{
+instruct vxor8B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 8);
   match(Set dst (XorV src1 src2));
   format %{ "vpxor   $dst,$src1,$src2\t! xor vectors (8 bytes)" %}
@@ -9273,7 +9325,7 @@ instruct vxor8B_reg(vecD dst, vecD src1, vecD src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor8B_mem(vecD dst, vecD src, memory mem) %{
+instruct vxor8B_mem(vec dst, vec src, memory mem) %{
   predicate((UseAVX > 0) && (n->as_Vector()->length_in_bytes() == 8) &&
     (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (XorV src (LoadVector mem)));
@@ -9285,7 +9337,7 @@ instruct vxor8B_mem(vecD dst, vecD src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor16B(vecX dst, vecX src) %{
+instruct vxor16B(vec dst, vec src) %{
   predicate(UseAVX == 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (XorV dst src));
   format %{ "pxor    $dst,$src\t! xor vectors (16 bytes)" %}
@@ -9295,7 +9347,7 @@ instruct vxor16B(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor16B_reg(vecX dst, vecX src1, vecX src2) %{
+instruct vxor16B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (XorV src1 src2));
   format %{ "vpxor   $dst,$src1,$src2\t! xor vectors (16 bytes)" %}
@@ -9306,7 +9358,7 @@ instruct vxor16B_reg(vecX dst, vecX src1, vecX src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor16B_mem(vecX dst, vecX src, memory mem) %{
+instruct vxor16B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 0 && n->as_Vector()->length_in_bytes() == 16);
   match(Set dst (XorV src (LoadVector mem)));
   format %{ "vpxor   $dst,$src,$mem\t! xor vectors (16 bytes)" %}
@@ -9317,7 +9369,7 @@ instruct vxor16B_mem(vecX dst, vecX src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor32B_reg(vecY dst, vecY src1, vecY src2) %{
+instruct vxor32B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 1 && n->as_Vector()->length_in_bytes() == 32);
   match(Set dst (XorV src1 src2));
   format %{ "vpxor   $dst,$src1,$src2\t! xor vectors (32 bytes)" %}
@@ -9328,7 +9380,7 @@ instruct vxor32B_reg(vecY dst, vecY src1, vecY src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor32B_mem(vecY dst, vecY src, memory mem) %{
+instruct vxor32B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 1 && n->as_Vector()->length_in_bytes() == 32);
   match(Set dst (XorV src (LoadVector mem)));
   format %{ "vpxor   $dst,$src,$mem\t! xor vectors (32 bytes)" %}
@@ -9339,7 +9391,7 @@ instruct vxor32B_mem(vecY dst, vecY src, memory mem) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
+instruct vxor64B_reg(vec dst, vec src1, vec src2) %{
   predicate(UseAVX > 2 && n->as_Vector()->length_in_bytes() == 64);
   match(Set dst (XorV src1 src2));
   format %{ "vpxor   $dst,$src1,$src2\t! xor vectors (64 bytes)" %}
@@ -9350,7 +9402,7 @@ instruct vxor64B_reg(vecZ dst, vecZ src1, vecZ src2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vxor64B_mem(vecZ dst, vecZ src, memory mem) %{
+instruct vxor64B_mem(vec dst, vec src, memory mem) %{
   predicate(UseAVX > 2 && n->as_Vector()->length_in_bytes() == 64);
   match(Set dst (XorV src (LoadVector mem)));
   format %{ "vpxor   $dst,$src,$mem\t! xor vectors (64 bytes)" %}
@@ -9363,7 +9415,7 @@ instruct vxor64B_mem(vecZ dst, vecZ src, memory mem) %{
 
 // --------------------------------- ABS --------------------------------------
 // a = |a|
-instruct vabs4B_reg(vecS dst, vecS src) %{
+instruct vabs4B_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 4);
   match(Set dst (AbsVB  src));
   format %{ "pabsb $dst,$src\t# $dst = |$src| abs packed4B" %}
@@ -9373,7 +9425,7 @@ instruct vabs4B_reg(vecS dst, vecS src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs8B_reg(vecD dst, vecD src) %{
+instruct vabs8B_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AbsVB  src));
   format %{ "pabsb $dst,$src\t# $dst = |$src| abs packed8B" %}
@@ -9383,7 +9435,7 @@ instruct vabs8B_reg(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs16B_reg(vecX dst, vecX src) %{
+instruct vabs16B_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 16);
   match(Set dst (AbsVB  src));
   format %{ "pabsb $dst,$src\t# $dst = |$src| abs packed16B" %}
@@ -9393,7 +9445,7 @@ instruct vabs16B_reg(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs32B_reg(vecY dst, vecY src) %{
+instruct vabs32B_reg(vec dst, vec src) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 32);
   match(Set dst (AbsVB  src));
   format %{ "vpabsb $dst,$src\t# $dst = |$src| abs packed32B" %}
@@ -9404,7 +9456,7 @@ instruct vabs32B_reg(vecY dst, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs64B_reg(vecZ dst, vecZ src) %{
+instruct vabs64B_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 64);
   match(Set dst (AbsVB  src));
   format %{ "vpabsb $dst,$src\t# $dst = |$src| abs packed64B" %}
@@ -9415,7 +9467,7 @@ instruct vabs64B_reg(vecZ dst, vecZ src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs2S_reg(vecD dst, vecD src) %{
+instruct vabs2S_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 2);
   match(Set dst (AbsVS  src));
   format %{ "pabsw $dst,$src\t# $dst = |$src| abs packed2S" %}
@@ -9425,7 +9477,7 @@ instruct vabs2S_reg(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs4S_reg(vecD dst, vecD src) %{
+instruct vabs4S_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 4);
   match(Set dst (AbsVS  src));
   format %{ "pabsw $dst,$src\t# $dst = |$src| abs packed4S" %}
@@ -9435,7 +9487,7 @@ instruct vabs4S_reg(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs8S_reg(vecX dst, vecX src) %{
+instruct vabs8S_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AbsVS  src));
   format %{ "pabsw $dst,$src\t# $dst = |$src| abs packed8S" %}
@@ -9445,7 +9497,7 @@ instruct vabs8S_reg(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs16S_reg(vecY dst, vecY src) %{
+instruct vabs16S_reg(vec dst, vec src) %{
   predicate(UseAVX > 1 && n->as_Vector()->length() == 16);
   match(Set dst (AbsVS  src));
   format %{ "vpabsw $dst,$src\t# $dst = |$src| abs packed16S" %}
@@ -9456,7 +9508,7 @@ instruct vabs16S_reg(vecY dst, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs32S_reg(vecZ dst, vecZ src) %{
+instruct vabs32S_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 32);
   match(Set dst (AbsVS  src));
   format %{ "vpabsw $dst,$src\t# $dst = |$src| abs packed32S" %}
@@ -9467,7 +9519,7 @@ instruct vabs32S_reg(vecZ dst, vecZ src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs2I_reg(vecD dst, vecD src) %{
+instruct vabs2I_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 2);
   match(Set dst (AbsVI  src));
   format %{ "pabsd $dst,$src\t# $dst = |$src| abs packed2I" %}
@@ -9477,7 +9529,7 @@ instruct vabs2I_reg(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs4I_reg(vecX dst, vecX src) %{
+instruct vabs4I_reg(vec dst, vec src) %{
   predicate(UseSSE > 2 && n->as_Vector()->length() == 4);
   match(Set dst (AbsVI  src));
   format %{ "pabsd $dst,$src\t# $dst = |$src| abs packed4I" %}
@@ -9487,7 +9539,7 @@ instruct vabs4I_reg(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs8I_reg(vecY dst, vecY src) %{
+instruct vabs8I_reg(vec dst, vec src) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (AbsVI src));
   format %{ "vpabsd $dst,$src\t# $dst = |$src| abs packed8I" %}
@@ -9498,7 +9550,7 @@ instruct vabs8I_reg(vecY dst, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs16I_reg(vecZ dst, vecZ src) %{
+instruct vabs16I_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (AbsVI src));
   format %{ "vpabsd $dst,$src\t# $dst = |$src| abs packed16I" %}
@@ -9509,7 +9561,7 @@ instruct vabs16I_reg(vecZ dst, vecZ src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs2L_reg(vecX dst, vecX src) %{
+instruct vabs2L_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 2);
   match(Set dst (AbsVL  src));
   format %{ "evpabsq $dst,$src\t# $dst = |$src| abs packed2L" %}
@@ -9520,7 +9572,7 @@ instruct vabs2L_reg(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs4L_reg(vecY dst, vecY src) %{
+instruct vabs4L_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 4);
   match(Set dst (AbsVL  src));
   format %{ "evpabsq $dst,$src\t# $dst = |$src| abs packed4L" %}
@@ -9531,7 +9583,7 @@ instruct vabs4L_reg(vecY dst, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabs8L_reg(vecZ dst, vecZ src) %{
+instruct vabs8L_reg(vec dst, vec src) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AbsVL  src));
   format %{ "evpabsq $dst,$src\t# $dst = |$src| abs packed8L" %}
@@ -9544,7 +9596,7 @@ instruct vabs8L_reg(vecZ dst, vecZ src) %{
 
 // --------------------------------- ABSNEG --------------------------------------
 
-instruct vabsneg2D(vecX dst, vecX src, rRegI scratch) %{
+instruct vabsneg2D(vec dst, vec src, rRegI scratch) %{
   predicate(UseSSE >= 2 && n->as_Vector()->length() == 2);
   match(Set dst (AbsVD  src));
   match(Set dst (NegVD  src));
@@ -9559,7 +9611,7 @@ instruct vabsneg2D(vecX dst, vecX src, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabsneg4D(vecY dst, vecY src, rRegI scratch) %{
+instruct vabsneg4D(vec dst, vec src, rRegI scratch) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AbsVD  src));
   match(Set dst (NegVD  src));
@@ -9573,7 +9625,7 @@ instruct vabsneg4D(vecY dst, vecY src, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabsneg8D(vecZ dst, vecZ src, rRegI scratch) %{
+instruct vabsneg8D(vec dst, vec src, rRegI scratch) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 8);
   match(Set dst (AbsVD  src));
   match(Set dst (NegVD  src));
@@ -9587,7 +9639,7 @@ instruct vabsneg8D(vecZ dst, vecZ src, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabsneg2F(vecD dst, vecD src, rRegI scratch) %{
+instruct vabsneg2F(vec dst, vec src, rRegI scratch) %{
   predicate(UseSSE > 0 && n->as_Vector()->length() == 2);
   match(Set dst (AbsVF  src));
   match(Set dst (NegVF  src));
@@ -9602,7 +9654,7 @@ instruct vabsneg2F(vecD dst, vecD src, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabsneg4F(vecX dst, rRegI scratch) %{
+instruct vabsneg4F(vec dst, rRegI scratch) %{
   predicate(UseSSE > 0 && n->as_Vector()->length() == 4);
   match(Set dst (AbsVF  dst));
   match(Set dst (NegVF  dst));
@@ -9616,7 +9668,7 @@ instruct vabsneg4F(vecX dst, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabsneg8F(vecY dst, vecY src, rRegI scratch) %{
+instruct vabsneg8F(vec dst, vec src, rRegI scratch) %{
   predicate(UseAVX > 0 && n->as_Vector()->length() == 8);
   match(Set dst (AbsVF  src));
   match(Set dst (NegVF  src));
@@ -9631,7 +9683,7 @@ instruct vabsneg8F(vecY dst, vecY src, rRegI scratch) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vabsneg16F(vecZ dst, vecZ src, rRegI scratch) %{
+instruct vabsneg16F(vec dst, vec src, rRegI scratch) %{
   predicate(UseAVX > 2 && n->as_Vector()->length() == 16);
   match(Set dst (AbsVF  src));
   match(Set dst (NegVF  src));
@@ -9649,7 +9701,7 @@ instruct vabsneg16F(vecZ dst, vecZ src, rRegI scratch) %{
 // --------------------------------- FMA --------------------------------------
 
 // a * b + c
-instruct vfma2D_reg(vecX a, vecX b, vecX c) %{
+instruct vfma2D_reg(vec a, vec b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 2);
   match(Set c (FmaVD  c (Binary a b)));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packed2D" %}
@@ -9662,7 +9714,7 @@ instruct vfma2D_reg(vecX a, vecX b, vecX c) %{
 %}
 
 // a * b + c
-instruct vfma2D_mem(vecX a, memory b, vecX c) %{
+instruct vfma2D_mem(vec a, memory b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 2);
   match(Set c (FmaVD  c (Binary a (LoadVector b))));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packed2D" %}
@@ -9676,7 +9728,7 @@ instruct vfma2D_mem(vecX a, memory b, vecX c) %{
 
 
 // a * b + c
-instruct vfma4D_reg(vecY a, vecY b, vecY c) %{
+instruct vfma4D_reg(vec a, vec b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 4);
   match(Set c (FmaVD  c (Binary a b)));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packed4D" %}
@@ -9689,7 +9741,7 @@ instruct vfma4D_reg(vecY a, vecY b, vecY c) %{
 %}
 
 // a * b + c
-instruct vfma4D_mem(vecY a, memory b, vecY c) %{
+instruct vfma4D_mem(vec a, memory b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 4);
   match(Set c (FmaVD  c (Binary a (LoadVector b))));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packed4D" %}
@@ -9702,7 +9754,7 @@ instruct vfma4D_mem(vecY a, memory b, vecY c) %{
 %}
 
 // a * b + c
-instruct vfma8D_reg(vecZ a, vecZ b, vecZ c) %{
+instruct vfma8D_reg(vec a, vec b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 8);
   match(Set c (FmaVD  c (Binary a b)));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packed8D" %}
@@ -9715,7 +9767,7 @@ instruct vfma8D_reg(vecZ a, vecZ b, vecZ c) %{
 %}
 
 // a * b + c
-instruct vfma8D_mem(vecZ a, memory b, vecZ c) %{
+instruct vfma8D_mem(vec a, memory b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 8);
   match(Set c (FmaVD  c (Binary a (LoadVector b))));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packed8D" %}
@@ -9728,7 +9780,7 @@ instruct vfma8D_mem(vecZ a, memory b, vecZ c) %{
 %}
 
 // a * b + c
-instruct vfma4F_reg(vecX a, vecX b, vecX c) %{
+instruct vfma4F_reg(vec a, vec b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 4);
   match(Set c (FmaVF  c (Binary a b)));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packed4F" %}
@@ -9741,7 +9793,7 @@ instruct vfma4F_reg(vecX a, vecX b, vecX c) %{
 %}
 
 // a * b + c
-instruct vfma4F_mem(vecX a, memory b, vecX c) %{
+instruct vfma4F_mem(vec a, memory b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 4);
   match(Set c (FmaVF  c (Binary a (LoadVector b))));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packed4F" %}
@@ -9754,7 +9806,7 @@ instruct vfma4F_mem(vecX a, memory b, vecX c) %{
 %}
 
 // a * b + c
-instruct vfma8F_reg(vecY a, vecY b, vecY c) %{
+instruct vfma8F_reg(vec a, vec b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 8);
   match(Set c (FmaVF  c (Binary a b)));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packed8F" %}
@@ -9767,7 +9819,7 @@ instruct vfma8F_reg(vecY a, vecY b, vecY c) %{
 %}
 
 // a * b + c
-instruct vfma8F_mem(vecY a, memory b, vecY c) %{
+instruct vfma8F_mem(vec a, memory b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 8);
   match(Set c (FmaVF  c (Binary a (LoadVector b))));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packed8F" %}
@@ -9780,7 +9832,7 @@ instruct vfma8F_mem(vecY a, memory b, vecY c) %{
 %}
 
 // a * b + c
-instruct vfma16F_reg(vecZ a, vecZ b, vecZ c) %{
+instruct vfma16F_reg(vec a, vec b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 16);
   match(Set c (FmaVF  c (Binary a b)));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packed16F" %}
@@ -9793,7 +9845,7 @@ instruct vfma16F_reg(vecZ a, vecZ b, vecZ c) %{
 %}
 
 // a * b + c
-instruct vfma16F_mem(vecZ a, memory b, vecZ c) %{
+instruct vfma16F_mem(vec a, memory b, vec c) %{
   predicate(UseFMA && n->as_Vector()->length() == 16);
   match(Set c (FmaVF  c (Binary a (LoadVector b))));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packed16F" %}
@@ -9807,7 +9859,7 @@ instruct vfma16F_mem(vecZ a, memory b, vecZ c) %{
 
 // --------------------------------- PopCount --------------------------------------
 
-instruct vpopcount2I(vecD dst, vecD src) %{
+instruct vpopcount2I(vec dst, vec src) %{
   predicate(VM_Version::supports_vpopcntdq() && UsePopCountInstruction && n->as_Vector()->length() == 2);
   match(Set dst (PopCountVI src));
   format %{ "vpopcntd  $dst,$src\t! vector popcount packed2I" %}
@@ -9818,7 +9870,7 @@ instruct vpopcount2I(vecD dst, vecD src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vpopcount4I(vecX dst, vecX src) %{
+instruct vpopcount4I(vec dst, vec src) %{
   predicate(VM_Version::supports_vpopcntdq() && UsePopCountInstruction && n->as_Vector()->length() == 4);
   match(Set dst (PopCountVI src));
   format %{ "vpopcntd  $dst,$src\t! vector popcount packed4I" %}
@@ -9829,7 +9881,7 @@ instruct vpopcount4I(vecX dst, vecX src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vpopcount8I(vecY dst, vecY src) %{
+instruct vpopcount8I(vec dst, vec src) %{
   predicate(VM_Version::supports_vpopcntdq() && UsePopCountInstruction && n->as_Vector()->length() == 8);
   match(Set dst (PopCountVI src));
   format %{ "vpopcntd  $dst,$src\t! vector popcount packed8I" %}
@@ -9840,7 +9892,7 @@ instruct vpopcount8I(vecY dst, vecY src) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vpopcount16I(vecZ dst, vecZ src) %{
+instruct vpopcount16I(vec dst, vec src) %{
   predicate(VM_Version::supports_vpopcntdq() && UsePopCountInstruction && n->as_Vector()->length() == 16);
   match(Set dst (PopCountVI src));
   format %{ "vpopcntd  $dst,$src\t! vector popcount packed16I" %}

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -4135,72 +4135,6 @@ operand vlRegD() %{
    interface(REG_INTER);
 %}
 
-// Vectors : note, we use legacy registers to avoid extra (unneeded in 32-bit VM)
-// runtime code generation via reg_class_dynamic.
-operand vecS() %{
-  constraint(ALLOC_IN_RC(vectors_reg_legacy));
-  match(VecS);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand legVecS() %{
-  constraint(ALLOC_IN_RC(vectors_reg_legacy));
-  match(VecS);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vecD() %{
-  constraint(ALLOC_IN_RC(vectord_reg_legacy));
-  match(VecD);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand legVecD() %{
-  constraint(ALLOC_IN_RC(vectord_reg_legacy));
-  match(VecD);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vecX() %{
-  constraint(ALLOC_IN_RC(vectorx_reg_legacy));
-  match(VecX);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand legVecX() %{
-  constraint(ALLOC_IN_RC(vectorx_reg_legacy));
-  match(VecX);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vecY() %{
-  constraint(ALLOC_IN_RC(vectory_reg_legacy));
-  match(VecY);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand legVecY() %{
-  constraint(ALLOC_IN_RC(vectory_reg_legacy));
-  match(VecY);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 //----------Memory Operands----------------------------------------------------
 // Direct Memory Operand
 operand direct(immP addr) %{
@@ -11786,12 +11720,12 @@ instruct string_equals(eDIRegP str1, eSIRegP str2, eCXRegI cnt, eAXRegI result,
 
 // fast search of substring with known size.
 instruct string_indexof_conL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int_cnt2,
-                             eBXRegI result, regD vec, eAXRegI cnt2, eCXRegI tmp, eFlagsReg cr) %{
+                             eBXRegI result, regD vec1, eAXRegI cnt2, eCXRegI tmp, eFlagsReg cr) %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::LL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 int_cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP vec1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
 
-  format %{ "String IndexOf byte[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec, $cnt1, $cnt2, $tmp" %}
+  format %{ "String IndexOf byte[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec1, $cnt1, $cnt2, $tmp" %}
   ins_encode %{
     int icnt2 = (int)$int_cnt2$$constant;
     if (icnt2 >= 16) {
@@ -11800,13 +11734,13 @@ instruct string_indexof_conL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int_
       __ string_indexofC8($str1$$Register, $str2$$Register,
                           $cnt1$$Register, $cnt2$$Register,
                           icnt2, $result$$Register,
-                          $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
+                          $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
     } else {
       // Small strings are loaded through stack if they cross page boundary.
       __ string_indexof($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register,
                         icnt2, $result$$Register,
-                        $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
+                        $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
     }
   %}
   ins_pipe( pipe_slow );
@@ -11814,12 +11748,12 @@ instruct string_indexof_conL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int_
 
 // fast search of substring with known size.
 instruct string_indexof_conU(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int_cnt2,
-                             eBXRegI result, regD vec, eAXRegI cnt2, eCXRegI tmp, eFlagsReg cr) %{
+                             eBXRegI result, regD vec1, eAXRegI cnt2, eCXRegI tmp, eFlagsReg cr) %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UU));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 int_cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP vec1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
 
-  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec, $cnt1, $cnt2, $tmp" %}
+  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec1, $cnt1, $cnt2, $tmp" %}
   ins_encode %{
     int icnt2 = (int)$int_cnt2$$constant;
     if (icnt2 >= 8) {
@@ -11828,13 +11762,13 @@ instruct string_indexof_conU(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int_
       __ string_indexofC8($str1$$Register, $str2$$Register,
                           $cnt1$$Register, $cnt2$$Register,
                           icnt2, $result$$Register,
-                          $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
+                          $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
     } else {
       // Small strings are loaded through stack if they cross page boundary.
       __ string_indexof($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register,
                         icnt2, $result$$Register,
-                        $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
+                        $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
     }
   %}
   ins_pipe( pipe_slow );
@@ -11842,12 +11776,12 @@ instruct string_indexof_conU(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int_
 
 // fast search of substring with known size.
 instruct string_indexof_conUL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int_cnt2,
-                             eBXRegI result, regD vec, eAXRegI cnt2, eCXRegI tmp, eFlagsReg cr) %{
+                             eBXRegI result, regD vec1, eAXRegI cnt2, eCXRegI tmp, eFlagsReg cr) %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 int_cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP vec1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
 
-  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec, $cnt1, $cnt2, $tmp" %}
+  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec1, $cnt1, $cnt2, $tmp" %}
   ins_encode %{
     int icnt2 = (int)$int_cnt2$$constant;
     if (icnt2 >= 8) {
@@ -11856,62 +11790,62 @@ instruct string_indexof_conUL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, immI int
       __ string_indexofC8($str1$$Register, $str2$$Register,
                           $cnt1$$Register, $cnt2$$Register,
                           icnt2, $result$$Register,
-                          $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
+                          $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
     } else {
       // Small strings are loaded through stack if they cross page boundary.
       __ string_indexof($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register,
                         icnt2, $result$$Register,
-                        $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
+                        $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
     }
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct string_indexofL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, eAXRegI cnt2,
-                         eBXRegI result, regD vec, eCXRegI tmp, eFlagsReg cr) %{
+                         eBXRegI result, regD vec1, eCXRegI tmp, eFlagsReg cr) %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::LL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP vec1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
 
   format %{ "String IndexOf byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof($str1$$Register, $str2$$Register,
                       $cnt1$$Register, $cnt2$$Register,
                       (-1), $result$$Register,
-                      $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
+                      $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct string_indexofU(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, eAXRegI cnt2,
-                         eBXRegI result, regD vec, eCXRegI tmp, eFlagsReg cr) %{
+                         eBXRegI result, regD vec1, eCXRegI tmp, eFlagsReg cr) %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UU));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP vec1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
 
   format %{ "String IndexOf char[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof($str1$$Register, $str2$$Register,
                       $cnt1$$Register, $cnt2$$Register,
                       (-1), $result$$Register,
-                      $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
+                      $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct string_indexofUL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, eAXRegI cnt2,
-                         eBXRegI result, regD vec, eCXRegI tmp, eFlagsReg cr) %{
+                         eBXRegI result, regD vec1, eCXRegI tmp, eFlagsReg cr) %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP vec1, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
 
   format %{ "String IndexOf char[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof($str1$$Register, $str2$$Register,
                       $cnt1$$Register, $cnt2$$Register,
                       (-1), $result$$Register,
-                      $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
+                      $vec1$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -3822,72 +3822,6 @@ operand vlRegD() %{
    interface(REG_INTER);
 %}
 
-// Vectors
-operand vecS() %{
-  constraint(ALLOC_IN_RC(vectors_reg_vlbwdq));
-  match(VecS);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-// Vectors
-operand legVecS() %{
-  constraint(ALLOC_IN_RC(vectors_reg_legacy));
-  match(VecS);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vecD() %{
-  constraint(ALLOC_IN_RC(vectord_reg_vlbwdq));
-  match(VecD);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand legVecD() %{
-  constraint(ALLOC_IN_RC(vectord_reg_legacy));
-  match(VecD);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vecX() %{
-  constraint(ALLOC_IN_RC(vectorx_reg_vlbwdq));
-  match(VecX);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand legVecX() %{
-  constraint(ALLOC_IN_RC(vectorx_reg_legacy));
-  match(VecX);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vecY() %{
-  constraint(ALLOC_IN_RC(vectory_reg_vlbwdq));
-  match(VecY);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand legVecY() %{
-  constraint(ALLOC_IN_RC(vectory_reg_legacy));
-  match(VecY);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 //----------Memory Operands----------------------------------------------------
 // Direct Memory Operand
 // operand direct(immP addr)
@@ -11328,7 +11262,7 @@ instruct rep_stos_large(rcx_RegL cnt, rdi_RegP base, regD tmp, rax_RegI zero,
 %}
 
 instruct string_compareL(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
-                         rax_RegI result, legVecS tmp1, rFlagsReg cr)
+                         rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(((StrCompNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
@@ -11344,7 +11278,7 @@ instruct string_compareL(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI c
 %}
 
 instruct string_compareU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
-                         rax_RegI result, legVecS tmp1, rFlagsReg cr)
+                         rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(((StrCompNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
@@ -11360,7 +11294,7 @@ instruct string_compareU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI c
 %}
 
 instruct string_compareLU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI cnt2,
-                          rax_RegI result, legVecS tmp1, rFlagsReg cr)
+                          rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(((StrCompNode*)n)->encoding() == StrIntrinsicNode::LU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
@@ -11376,7 +11310,7 @@ instruct string_compareLU(rdi_RegP str1, rcx_RegI cnt1, rsi_RegP str2, rdx_RegI 
 %}
 
 instruct string_compareUL(rsi_RegP str1, rdx_RegI cnt1, rdi_RegP str2, rcx_RegI cnt2,
-                          rax_RegI result, legVecS tmp1, rFlagsReg cr)
+                          rax_RegI result, legRegD tmp1, rFlagsReg cr)
 %{
   predicate(((StrCompNode*)n)->encoding() == StrIntrinsicNode::UL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
@@ -11393,13 +11327,13 @@ instruct string_compareUL(rsi_RegP str1, rdx_RegI cnt1, rdi_RegP str2, rcx_RegI 
 
 // fast search of substring with known size.
 instruct string_indexof_conL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI int_cnt2,
-                             rbx_RegI result, legVecS vec, rax_RegI cnt2, rcx_RegI tmp, rFlagsReg cr)
+                             rbx_RegI result, legRegD tmp_vec, rax_RegI cnt2, rcx_RegI tmp, rFlagsReg cr)
 %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::LL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 int_cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP tmp_vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
 
-  format %{ "String IndexOf byte[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec, $cnt1, $cnt2, $tmp" %}
+  format %{ "String IndexOf byte[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $tmp_vec, $cnt1, $cnt2, $tmp" %}
   ins_encode %{
     int icnt2 = (int)$int_cnt2$$constant;
     if (icnt2 >= 16) {
@@ -11408,13 +11342,13 @@ instruct string_indexof_conL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI i
       __ string_indexofC8($str1$$Register, $str2$$Register,
                           $cnt1$$Register, $cnt2$$Register,
                           icnt2, $result$$Register,
-                          $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
+                          $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
     } else {
       // Small strings are loaded through stack if they cross page boundary.
       __ string_indexof($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register,
                         icnt2, $result$$Register,
-                        $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
+                        $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
     }
   %}
   ins_pipe( pipe_slow );
@@ -11422,13 +11356,13 @@ instruct string_indexof_conL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI i
 
 // fast search of substring with known size.
 instruct string_indexof_conU(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI int_cnt2,
-                             rbx_RegI result, legVecS vec, rax_RegI cnt2, rcx_RegI tmp, rFlagsReg cr)
+                             rbx_RegI result, legRegD tmp_vec, rax_RegI cnt2, rcx_RegI tmp, rFlagsReg cr)
 %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UU));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 int_cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP tmp_vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
 
-  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec, $cnt1, $cnt2, $tmp" %}
+  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $tmp_vec, $cnt1, $cnt2, $tmp" %}
   ins_encode %{
     int icnt2 = (int)$int_cnt2$$constant;
     if (icnt2 >= 8) {
@@ -11437,13 +11371,13 @@ instruct string_indexof_conU(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI i
       __ string_indexofC8($str1$$Register, $str2$$Register,
                           $cnt1$$Register, $cnt2$$Register,
                           icnt2, $result$$Register,
-                          $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
+                          $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
     } else {
       // Small strings are loaded through stack if they cross page boundary.
       __ string_indexof($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register,
                         icnt2, $result$$Register,
-                        $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
+                        $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
     }
   %}
   ins_pipe( pipe_slow );
@@ -11451,13 +11385,13 @@ instruct string_indexof_conU(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI i
 
 // fast search of substring with known size.
 instruct string_indexof_conUL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI int_cnt2,
-                             rbx_RegI result, legVecS vec, rax_RegI cnt2, rcx_RegI tmp, rFlagsReg cr)
+                              rbx_RegI result, legRegD tmp_vec, rax_RegI cnt2, rcx_RegI tmp, rFlagsReg cr)
 %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 int_cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP tmp_vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, KILL cnt2, KILL tmp, KILL cr);
 
-  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $vec, $cnt1, $cnt2, $tmp" %}
+  format %{ "String IndexOf char[] $str1,$cnt1,$str2,$int_cnt2 -> $result   // KILL $tmp_vec, $cnt1, $cnt2, $tmp" %}
   ins_encode %{
     int icnt2 = (int)$int_cnt2$$constant;
     if (icnt2 >= 8) {
@@ -11466,86 +11400,86 @@ instruct string_indexof_conUL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, immI 
       __ string_indexofC8($str1$$Register, $str2$$Register,
                           $cnt1$$Register, $cnt2$$Register,
                           icnt2, $result$$Register,
-                          $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
+                          $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
     } else {
       // Small strings are loaded through stack if they cross page boundary.
       __ string_indexof($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register,
                         icnt2, $result$$Register,
-                        $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
+                        $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
     }
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct string_indexofL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, rax_RegI cnt2,
-                         rbx_RegI result, legVecS vec, rcx_RegI tmp, rFlagsReg cr)
+                         rbx_RegI result, legRegD tmp_vec, rcx_RegI tmp, rFlagsReg cr)
 %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::LL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP tmp_vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
 
   format %{ "String IndexOf byte[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof($str1$$Register, $str2$$Register,
                       $cnt1$$Register, $cnt2$$Register,
                       (-1), $result$$Register,
-                      $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
+                      $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::LL);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct string_indexofU(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, rax_RegI cnt2,
-                         rbx_RegI result, legVecS vec, rcx_RegI tmp, rFlagsReg cr)
+                         rbx_RegI result, legRegD tmp_vec, rcx_RegI tmp, rFlagsReg cr)
 %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UU));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP tmp_vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
 
   format %{ "String IndexOf char[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof($str1$$Register, $str2$$Register,
                       $cnt1$$Register, $cnt2$$Register,
                       (-1), $result$$Register,
-                      $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
+                      $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UU);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct string_indexofUL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, rax_RegI cnt2,
-                         rbx_RegI result, legVecS vec, rcx_RegI tmp, rFlagsReg cr)
+                          rbx_RegI result, legRegD tmp_vec, rcx_RegI tmp, rFlagsReg cr)
 %{
   predicate(UseSSE42Intrinsics && (((StrIndexOfNode*)n)->encoding() == StrIntrinsicNode::UL));
   match(Set result (StrIndexOf (Binary str1 cnt1) (Binary str2 cnt2)));
-  effect(TEMP vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
+  effect(TEMP tmp_vec, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL tmp, KILL cr);
 
   format %{ "String IndexOf char[] $str1,$cnt1,$str2,$cnt2 -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof($str1$$Register, $str2$$Register,
                       $cnt1$$Register, $cnt2$$Register,
                       (-1), $result$$Register,
-                      $vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
+                      $tmp_vec$$XMMRegister, $tmp$$Register, StrIntrinsicNode::UL);
   %}
   ins_pipe( pipe_slow );
 %}
 
 instruct string_indexofU_char(rdi_RegP str1, rdx_RegI cnt1, rax_RegI ch,
-                              rbx_RegI result, legVecS vec1, legVecS vec2, legVecS vec3, rcx_RegI tmp, rFlagsReg cr)
+                              rbx_RegI result, legRegD tmp_vec1, legRegD tmp_vec2, legRegD tmp_vec3, rcx_RegI tmp, rFlagsReg cr)
 %{
   predicate(UseSSE42Intrinsics);
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
-  effect(TEMP vec1, TEMP vec2, TEMP vec3, USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP tmp, KILL cr);
+  effect(TEMP tmp_vec1, TEMP tmp_vec2, TEMP tmp_vec3, USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP tmp, KILL cr);
   format %{ "String IndexOf char[] $str1,$cnt1,$ch -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register, $result$$Register,
-                           $vec1$$XMMRegister, $vec2$$XMMRegister, $vec3$$XMMRegister, $tmp$$Register);
+                           $tmp_vec1$$XMMRegister, $tmp_vec2$$XMMRegister, $tmp_vec3$$XMMRegister, $tmp$$Register);
   %}
   ins_pipe( pipe_slow );
 %}
 
 // fast string equals
 instruct string_equals(rdi_RegP str1, rsi_RegP str2, rcx_RegI cnt, rax_RegI result,
-                       legVecS tmp1, legVecS tmp2, rbx_RegI tmp3, rFlagsReg cr)
+                       legRegD tmp1, legRegD tmp2, rbx_RegI tmp3, rFlagsReg cr)
 %{
   match(Set result (StrEquals (Binary str1 str2) cnt));
   effect(TEMP tmp1, TEMP tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt, KILL tmp3, KILL cr);
@@ -11561,7 +11495,7 @@ instruct string_equals(rdi_RegP str1, rsi_RegP str2, rcx_RegI cnt, rax_RegI resu
 
 // fast array equals
 instruct array_equalsB(rdi_RegP ary1, rsi_RegP ary2, rax_RegI result,
-                       legVecS tmp1, legVecS tmp2, rcx_RegI tmp3, rbx_RegI tmp4, rFlagsReg cr)
+                       legRegD tmp1, legRegD tmp2, rcx_RegI tmp3, rbx_RegI tmp4, rFlagsReg cr)
 %{
   predicate(((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (AryEq ary1 ary2));
@@ -11577,7 +11511,7 @@ instruct array_equalsB(rdi_RegP ary1, rsi_RegP ary2, rax_RegI result,
 %}
 
 instruct array_equalsC(rdi_RegP ary1, rsi_RegP ary2, rax_RegI result,
-                      legVecS tmp1, legVecS tmp2, rcx_RegI tmp3, rbx_RegI tmp4, rFlagsReg cr)
+                       legRegD tmp1, legRegD tmp2, rcx_RegI tmp3, rbx_RegI tmp4, rFlagsReg cr)
 %{
   predicate(((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (AryEq ary1 ary2));
@@ -11593,7 +11527,7 @@ instruct array_equalsC(rdi_RegP ary1, rsi_RegP ary2, rax_RegI result,
 %}
 
 instruct has_negatives(rsi_RegP ary1, rcx_RegI len, rax_RegI result,
-                      legVecS tmp1, legVecS tmp2, rbx_RegI tmp3, rFlagsReg cr)
+                       legRegD tmp1, legRegD tmp2, rbx_RegI tmp3, rFlagsReg cr)
 %{
   match(Set result (HasNegatives ary1 len));
   effect(TEMP tmp1, TEMP tmp2, USE_KILL ary1, USE_KILL len, KILL tmp3, KILL cr);
@@ -11608,7 +11542,7 @@ instruct has_negatives(rsi_RegP ary1, rcx_RegI len, rax_RegI result,
 %}
 
 // fast char[] to byte[] compression
-instruct string_compress(rsi_RegP src, rdi_RegP dst, rdx_RegI len, legVecS tmp1, legVecS tmp2, legVecS tmp3, legVecS tmp4,
+instruct string_compress(rsi_RegP src, rdi_RegP dst, rdx_RegI len, legRegD tmp1, legRegD tmp2, legRegD tmp3, legRegD tmp4,
                          rcx_RegI tmp5, rax_RegI result, rFlagsReg cr) %{
   match(Set result (StrCompressedCopy src (Binary dst len)));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, USE_KILL src, USE_KILL dst, USE_KILL len, KILL tmp5, KILL cr);
@@ -11624,7 +11558,7 @@ instruct string_compress(rsi_RegP src, rdi_RegP dst, rdx_RegI len, legVecS tmp1,
 
 // fast byte[] to char[] inflation
 instruct string_inflate(Universe dummy, rsi_RegP src, rdi_RegP dst, rdx_RegI len,
-                        legVecS tmp1, rcx_RegI tmp2, rFlagsReg cr) %{
+                        legRegD tmp1, rcx_RegI tmp2, rFlagsReg cr) %{
   match(Set dummy (StrInflatedCopy src (Binary dst len)));
   effect(TEMP tmp1, TEMP tmp2, USE_KILL src, USE_KILL dst, USE_KILL len, KILL cr);
 
@@ -11638,7 +11572,7 @@ instruct string_inflate(Universe dummy, rsi_RegP src, rdi_RegP dst, rdx_RegI len
 
 // encode char[] to byte[] in ISO_8859_1
 instruct encode_iso_array(rsi_RegP src, rdi_RegP dst, rdx_RegI len,
-                          legVecS tmp1, legVecS tmp2, legVecS tmp3, legVecS tmp4,
+                          legRegD tmp1, legRegD tmp2, legRegD tmp3, legRegD tmp4,
                           rcx_RegI tmp5, rax_RegI result, rFlagsReg cr) %{
   match(Set result (EncodeISOArray src (Binary dst len)));
   effect(TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, USE_KILL src, USE_KILL dst, USE_KILL len, KILL tmp5, KILL cr);

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -1577,6 +1577,8 @@ void ArchDesc::declareClasses(FILE *fp) {
     fprintf(fp,"    assert(operand_index < _num_opnds, \"invalid _opnd_array index\");\n");
     fprintf(fp,"    _opnd_array[operand_index] = operand;\n");
     fprintf(fp,"  }\n");
+    fprintf(fp,"  virtual uint           rule() const { return %s_rule; }\n",
+            instr->_ident);
     fprintf(fp,"private:\n");
     if ( instr->is_ideal_jump() ) {
       fprintf(fp,"  virtual void           add_case_label(int index_num, Label* blockLabel) {\n");
@@ -1588,8 +1590,6 @@ void ArchDesc::declareClasses(FILE *fp) {
     }
 
     out_RegMask(fp);                      // output register mask
-    fprintf(fp,"  virtual uint           rule() const { return %s_rule; }\n",
-            instr->_ident);
 
     // If this instruction contains a labelOper
     // Declare Node::methods that set operand Label's contents

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2494,7 +2494,11 @@ void Compile::Code_Gen() {
   {
     TracePhase tp("matcher", &timers[_t_matcher]);
     matcher.match();
+    if (failing()) {
+      return;
+    }
   }
+
   // In debug mode can dump m._nodes.dump() for mapping of ideal to machine
   // nodes.  Mapping is only valid at the root of each matched subtree.
   NOT_PRODUCT( verify_graph_edges(); )

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -393,10 +393,10 @@ const class TypePtr *MachNode::adr_type() const {
 
 
 //-----------------------------operand_index---------------------------------
-int MachNode::operand_index( uint operand ) const {
-  if( operand < 1 )  return -1;
+int MachNode::operand_index(uint operand) const {
+  if (operand < 1)  return -1;
   assert(operand < num_opnds(), "oob");
-  if( _opnds[operand]->num_edges() == 0 )  return -1;
+  if (_opnds[operand]->num_edges() == 0)  return -1;
 
   uint skipped   = oper_input_base(); // Sum of leaves skipped so far
   for (uint opcnt = 1; opcnt < operand; opcnt++) {
@@ -416,6 +416,20 @@ int MachNode::operand_index(const MachOper *oper) const {
   }
   if (_opnds[opcnt] != oper) return -1;
   return skipped;
+}
+
+int MachNode::operand_index(Node* def) const {
+  uint skipped = oper_input_base(); // Sum of leaves skipped so far
+  for (uint opcnt = 1; opcnt < num_opnds(); opcnt++) {
+    uint num_edges = _opnds[opcnt]->num_edges(); // leaves for operand
+    for (uint i = 0; i < num_edges; i++) {
+      if (in(skipped + i) == def) {
+        return opcnt;
+      }
+    }
+    skipped += num_edges;
+  }
+  return -1;
 }
 
 //------------------------------peephole---------------------------------------

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -246,6 +246,7 @@ public:
   // First index in _in[] corresponding to operand, or -1 if there is none
   int  operand_index(uint operand) const;
   int  operand_index(const MachOper *oper) const;
+  int  operand_index(Node* m) const;
 
   // Register class input is expected in
   virtual const RegMask &in_RegMask(uint) const;

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -389,10 +389,16 @@ void Matcher::match( ) {
   NOT_DEBUG( old->destruct_contents() );
 
   // ------------------------
-  // Set up save-on-entry registers
+  // Set up save-on-entry registers.
   Fixup_Save_On_Entry( );
-}
 
+  { // Cleanup mach IR after selection phase is over.
+    Compile::TracePhase tp("postselect_cleanup", &timers[_t_postselect_cleanup]);
+    do_postselect_cleanup();
+    if (C->failing())  return;
+    assert(verify_after_postselect_cleanup(), "");
+  }
+}
 
 //------------------------------Fixup_Save_On_Entry----------------------------
 // The stated purpose of this routine is to take care of save-on-entry
@@ -842,54 +848,23 @@ void Matcher::init_spill_mask( Node *ret ) {
 
   // Grab the Frame Pointer
   Node *fp  = ret->in(TypeFunc::FramePtr);
-  Node *mem = ret->in(TypeFunc::Memory);
-  const TypePtr* atp = TypePtr::BOTTOM;
   // Share frame pointer while making spill ops
   set_shared(fp);
 
-  // Compute generic short-offset Loads
+// Get the ADLC notion of the right regmask, for each basic type.
 #ifdef _LP64
-  MachNode *spillCP = match_tree(new LoadNNode(NULL,mem,fp,atp,TypeInstPtr::BOTTOM,MemNode::unordered));
+  idealreg2regmask[Op_RegN] = regmask_for_ideal_register(Op_RegN, ret);
 #endif
-  MachNode *spillI  = match_tree(new LoadINode(NULL,mem,fp,atp,TypeInt::INT,MemNode::unordered));
-  MachNode *spillL  = match_tree(new LoadLNode(NULL,mem,fp,atp,TypeLong::LONG,MemNode::unordered, LoadNode::DependsOnlyOnTest, false));
-  MachNode *spillF  = match_tree(new LoadFNode(NULL,mem,fp,atp,Type::FLOAT,MemNode::unordered));
-  MachNode *spillD  = match_tree(new LoadDNode(NULL,mem,fp,atp,Type::DOUBLE,MemNode::unordered));
-  MachNode *spillP  = match_tree(new LoadPNode(NULL,mem,fp,atp,TypeInstPtr::BOTTOM,MemNode::unordered));
-  assert(spillI != NULL && spillL != NULL && spillF != NULL &&
-         spillD != NULL && spillP != NULL, "");
-  // Get the ADLC notion of the right regmask, for each basic type.
-#ifdef _LP64
-  idealreg2regmask[Op_RegN] = &spillCP->out_RegMask();
-#endif
-  idealreg2regmask[Op_RegI] = &spillI->out_RegMask();
-  idealreg2regmask[Op_RegL] = &spillL->out_RegMask();
-  idealreg2regmask[Op_RegF] = &spillF->out_RegMask();
-  idealreg2regmask[Op_RegD] = &spillD->out_RegMask();
-  idealreg2regmask[Op_RegP] = &spillP->out_RegMask();
-
-  // Vector regmasks.
-  if (Matcher::vector_size_supported(T_BYTE,4)) {
-    TypeVect::VECTS = TypeVect::make(T_BYTE, 4);
-    MachNode *spillVectS = match_tree(new LoadVectorNode(NULL,mem,fp,atp,TypeVect::VECTS));
-    idealreg2regmask[Op_VecS] = &spillVectS->out_RegMask();
-  }
-  if (Matcher::vector_size_supported(T_FLOAT,2)) {
-    MachNode *spillVectD = match_tree(new LoadVectorNode(NULL,mem,fp,atp,TypeVect::VECTD));
-    idealreg2regmask[Op_VecD] = &spillVectD->out_RegMask();
-  }
-  if (Matcher::vector_size_supported(T_FLOAT,4)) {
-    MachNode *spillVectX = match_tree(new LoadVectorNode(NULL,mem,fp,atp,TypeVect::VECTX));
-    idealreg2regmask[Op_VecX] = &spillVectX->out_RegMask();
-  }
-  if (Matcher::vector_size_supported(T_FLOAT,8)) {
-    MachNode *spillVectY = match_tree(new LoadVectorNode(NULL,mem,fp,atp,TypeVect::VECTY));
-    idealreg2regmask[Op_VecY] = &spillVectY->out_RegMask();
-  }
-  if (Matcher::vector_size_supported(T_FLOAT,16)) {
-    MachNode *spillVectZ = match_tree(new LoadVectorNode(NULL,mem,fp,atp,TypeVect::VECTZ));
-    idealreg2regmask[Op_VecZ] = &spillVectZ->out_RegMask();
-  }
+  idealreg2regmask[Op_RegI] = regmask_for_ideal_register(Op_RegI, ret);
+  idealreg2regmask[Op_RegP] = regmask_for_ideal_register(Op_RegP, ret);
+  idealreg2regmask[Op_RegF] = regmask_for_ideal_register(Op_RegF, ret);
+  idealreg2regmask[Op_RegD] = regmask_for_ideal_register(Op_RegD, ret);
+  idealreg2regmask[Op_RegL] = regmask_for_ideal_register(Op_RegL, ret);
+  idealreg2regmask[Op_VecS] = regmask_for_ideal_register(Op_VecS, ret);
+  idealreg2regmask[Op_VecD] = regmask_for_ideal_register(Op_VecD, ret);
+  idealreg2regmask[Op_VecX] = regmask_for_ideal_register(Op_VecX, ret);
+  idealreg2regmask[Op_VecY] = regmask_for_ideal_register(Op_VecY, ret);
+  idealreg2regmask[Op_VecZ] = regmask_for_ideal_register(Op_VecZ, ret);
 }
 
 #ifdef ASSERT
@@ -2484,6 +2459,180 @@ void Matcher::validate_null_checks( ) {
     }
   }
 }
+
+bool Matcher::gen_narrow_oop_implicit_null_checks() {
+  // Advice matcher to perform null checks on the narrow oop side.
+  // Implicit checks are not possible on the uncompressed oop side anyway
+  // (at least not for read accesses).
+  // Performs significantly better (especially on Power 6).
+  if (!os::zero_page_read_protected()) {
+    return true;
+  }
+  return Universe::narrow_oop_use_implicit_null_checks &&
+         (narrow_oop_use_complex_address() ||
+           Universe::narrow_oop_base()!= NULL);
+}
+
+// Compute RegMask for an ideal register.
+const RegMask* Matcher::regmask_for_ideal_register(uint ideal_reg, Node* ret) {
+  const Type* t = Type::mreg2type[ideal_reg];
+  if (t == NULL) {
+    assert(ideal_reg >= Op_VecS && ideal_reg <= Op_VecZ, "not a vector: %d", ideal_reg);
+    return NULL; // not supported
+  }
+  Node* fp  = ret->in(TypeFunc::FramePtr);
+  Node* mem = ret->in(TypeFunc::Memory);
+  const TypePtr* atp = TypePtr::BOTTOM;
+  MemNode::MemOrd mo = MemNode::unordered;
+
+  Node* spill;
+  switch (ideal_reg) {
+    case Op_RegN: spill = new LoadNNode(NULL, mem, fp, atp, t->is_narrowoop(), mo); break;
+    case Op_RegI: spill = new LoadINode(NULL, mem, fp, atp, t->is_int(),       mo); break;
+    case Op_RegP: spill = new LoadPNode(NULL, mem, fp, atp, t->is_ptr(),       mo); break;
+    case Op_RegF: spill = new LoadFNode(NULL, mem, fp, atp, t,                 mo); break;
+    case Op_RegD: spill = new LoadDNode(NULL, mem, fp, atp, t,                 mo); break;
+    case Op_RegL: spill = new LoadLNode(NULL, mem, fp, atp, t->is_long(),      mo); break;
+
+    case Op_VecS: // fall-through
+    case Op_VecD: // fall-through
+    case Op_VecX: // fall-through
+    case Op_VecY: // fall-through
+    case Op_VecZ: spill = new LoadVectorNode(NULL, mem, fp, atp, t->is_vect()); break;
+
+    default: ShouldNotReachHere(); spill = NULL;
+  }
+  MachNode* mspill = match_tree(spill);
+  assert(mspill != NULL, "matching failed: %d", ideal_reg);
+  // Handle generic vector operand case
+  if (Matcher::supports_generic_vector_operands && t->isa_vect()) {
+    specialize_mach_node(mspill);
+  }
+  return &mspill->out_RegMask();
+}
+
+// Process Mach IR right after selection phase is over.
+void Matcher::do_postselect_cleanup() {
+  if (supports_generic_vector_operands) {
+    specialize_generic_vector_operands();
+    if (C->failing())  return;
+  }
+}
+
+//----------------------------------------------------------------------
+// Generic machine operands elision.
+//----------------------------------------------------------------------
+
+// Convert (leg)Vec to (leg)Vec[SDXYZ].
+MachOper* Matcher::specialize_vector_operand_helper(MachNode* m, MachOper* original_opnd) {
+  const Type* t = m->bottom_type();
+  uint ideal_reg = t->ideal_reg();
+  // Handle special cases
+  if (t->isa_vect()) {
+    // RShiftCntV/RShiftCntV report wide vector type, but VecS as ideal register (see vectornode.hpp).
+    if (m->ideal_Opcode() == Op_RShiftCntV || m->ideal_Opcode() == Op_LShiftCntV) {
+      ideal_reg = TypeVect::VECTS->ideal_reg(); // ideal_reg == Op_VecS
+    }
+  } else {
+    // Chain instructions which convert scalar to vector (e.g., vshiftcntimm on x86) don't have vector type.
+    int size_in_bytes = 4 * type2size[t->basic_type()];
+    ideal_reg = Matcher::vector_ideal_reg(size_in_bytes);
+  }
+  return Matcher::specialize_generic_vector_operand(original_opnd, ideal_reg);
+}
+
+// Compute concrete vector operand for a generic TEMP vector mach node based on its user info.
+void Matcher::specialize_temp_node(MachTempNode* tmp, MachNode* use, uint idx) {
+  assert(use->in(idx) == tmp, "not a user");
+  assert(!Matcher::is_generic_vector(use->_opnds[0]), "use not processed yet");
+
+  if ((uint)idx == use->two_adr()) { // DEF_TEMP case
+    tmp->_opnds[0] = use->_opnds[0]->clone();
+  } else {
+    uint ideal_vreg = vector_ideal_reg(C->max_vector_size());
+    tmp->_opnds[0] = specialize_generic_vector_operand(tmp->_opnds[0], ideal_vreg);
+  }
+}
+
+// Compute concrete vector operand for a generic DEF/USE vector operand (of mach node m at index idx).
+MachOper* Matcher::specialize_vector_operand(MachNode* m, uint idx) {
+  assert(Matcher::is_generic_vector(m->_opnds[idx]), "repeated updates");
+  if (idx == 0) { // DEF
+    // Use mach node itself to compute vector operand type.
+    return specialize_vector_operand_helper(m, m->_opnds[0]);
+  } else {
+    // Use def node to compute operand type.
+    int base_idx = m->operand_index(idx);
+    MachNode* in = m->in(base_idx)->as_Mach();
+    if (in->is_MachTemp() && Matcher::is_generic_vector(in->_opnds[0])) {
+      specialize_temp_node(in->as_MachTemp(), m, base_idx); // MachTemp node use site
+    } else if (is_generic_reg2reg_move(in)) {
+      in = in->in(1)->as_Mach(); // skip over generic reg-to-reg moves
+    }
+    return specialize_vector_operand_helper(in, m->_opnds[idx]);
+  }
+}
+
+void Matcher::specialize_mach_node(MachNode* m) {
+  assert(!m->is_MachTemp(), "processed along with its user");
+  // For generic use operands pull specific register class operands from
+  // its def instruction's output operand (def operand).
+  for (uint i = 0; i < m->num_opnds(); i++) {
+    if (Matcher::is_generic_vector(m->_opnds[i])) {
+      m->_opnds[i] = specialize_vector_operand(m, i);
+    }
+  }
+}
+
+// Replace generic vector operands with concrete vector operands and eliminate generic reg-to-reg moves from the graph.
+void Matcher::specialize_generic_vector_operands() {
+  assert(supports_generic_vector_operands, "sanity");
+  ResourceMark rm;
+
+  if (C->max_vector_size() == 0) {
+    return; // no vector instructions or operands
+  }
+  // Replace generic vector operands (vec/legVec) with concrete ones (vec[SDXYZ]/legVec[SDXYZ])
+  // and remove reg-to-reg vector moves (MoveVec2Leg and MoveLeg2Vec).
+  Unique_Node_List live_nodes;
+  C->identify_useful_nodes(live_nodes);
+
+  while (live_nodes.size() > 0) {
+    MachNode* m = live_nodes.pop()->isa_Mach();
+    if (m != NULL) {
+      if (Matcher::is_generic_reg2reg_move(m)) {
+        // Register allocator properly handles vec <=> leg moves using register masks.
+        int opnd_idx = m->operand_index(1);
+        Node* def = m->in(opnd_idx);
+        m->subsume_by(def, C);
+      } else if (m->is_MachTemp()) {
+        // process MachTemp nodes at use site (see Matcher::specialize_vector_operand)
+      } else {
+        specialize_mach_node(m);
+      }
+    }
+  }
+}
+
+#ifdef ASSERT
+bool Matcher::verify_after_postselect_cleanup() {
+  assert(!C->failing(), "sanity");
+  if (supports_generic_vector_operands) {
+    Unique_Node_List useful;
+    C->identify_useful_nodes(useful);
+    for (uint i = 0; i < useful.size(); i++) {
+      MachNode* m = useful.at(i)->isa_Mach();
+      if (m != NULL) {
+        assert(!Matcher::is_generic_reg2reg_move(m), "no MoveVec nodes allowed");
+        for (uint j = 0; j < m->num_opnds(); j++) {
+          assert(!Matcher::is_generic_vector(m->_opnds[j]), "no generic vector operands allowed");
+        }
+      }
+    }
+  }
+  return true;
+}
+#endif // ASSERT
 
 // Used by the DFA in dfa_xxx.cpp.  Check for a following barrier or
 // atomic instruction acting as a store_load barrier without any

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -2460,19 +2460,6 @@ void Matcher::validate_null_checks( ) {
   }
 }
 
-bool Matcher::gen_narrow_oop_implicit_null_checks() {
-  // Advice matcher to perform null checks on the narrow oop side.
-  // Implicit checks are not possible on the uncompressed oop side anyway
-  // (at least not for read accesses).
-  // Performs significantly better (especially on Power 6).
-  if (!os::zero_page_read_protected()) {
-    return true;
-  }
-  return Universe::narrow_oop_use_implicit_null_checks &&
-         (narrow_oop_use_complex_address() ||
-           Universe::narrow_oop_base()!= NULL);
-}
-
 // Compute RegMask for an ideal register.
 const RegMask* Matcher::regmask_for_ideal_register(uint ideal_reg, Node* ret) {
   const Type* t = Type::mreg2type[ideal_reg];

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -484,7 +484,18 @@ public:
   // [oop_reg + offset]
   // NullCheck oop_reg
   //
-  static bool gen_narrow_oop_implicit_null_checks();
+  inline static bool gen_narrow_oop_implicit_null_checks() {
+    // Advice matcher to perform null checks on the narrow oop side.
+    // Implicit checks are not possible on the uncompressed oop side anyway
+    // (at least not for read accesses).
+    // Performs significantly better (especially on Power 6).
+    if (!os::zero_page_read_protected()) {
+      return true;
+    }
+    return Universe::narrow_oop_use_implicit_null_checks() &&
+           (narrow_oop_use_complex_address() ||
+            Universe::narrow_oop_base() != NULL);
+  }
 
   // Is it better to copy float constants, or load them directly from memory?
   // Intel can load a float constant from a direct address, requiring no

--- a/src/hotspot/share/opto/phase.cpp
+++ b/src/hotspot/share/opto/phase.cpp
@@ -101,8 +101,11 @@ void Phase::print_timers() {
     }
   }
 
-  tty->print_cr ("       Matcher:             %7.3f s", timers[_t_matcher].seconds());
-  tty->print_cr ("       Scheduler:           %7.3f s", timers[_t_scheduler].seconds());
+  tty->print_cr ("       Matcher:                  %7.3f s", timers[_t_matcher].seconds());
+  if (Matcher::supports_generic_vector_operands) {
+    tty->print_cr ("         Post Selection Cleanup: %7.3f s", timers[_t_postselect_cleanup].seconds());
+  }
+  tty->print_cr ("       Scheduler:                %7.3f s", timers[_t_scheduler].seconds());
 
   {
     tty->print_cr ("       Regalloc:            %7.3f s", timers[_t_registerAllocation].seconds());

--- a/src/hotspot/share/opto/phase.hpp
+++ b/src/hotspot/share/opto/phase.hpp
@@ -82,6 +82,7 @@ public:
       _t_macroExpand,
       _t_graphReshaping,
     _t_matcher,
+      _t_postselect_cleanup,
     _t_scheduler,
     _t_registerAllocation,
       _t_ctorChaitin,


### PR DESCRIPTION
[Backport] 8234391 C2: Generic vector operands & 8234392 C2: Extend Matcher::match_rule_supported_vector() with element type information

Summary: Backport VectorAPI 8234391 C2: Generic vector operands & 8234392 C2: Extend Matcher::match_rule_supported_vector() with element type information. Merge 8234391 & 8234392

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/277