### PR TITLE
[Backport] 8235825: C2: Merge AD instructions for Replicate nodes

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1812,16 +1812,6 @@ bool Matcher::clone_address_expressions(AddPNode* m, Matcher::MStack& mstack, Ve
 void Compile::reshape_address(AddPNode* addp) {
 }
 
-static inline uint vector_length(const MachNode* n) {
-  const TypeVect* vt = n->bottom_type()->is_vect();
-  return vt->length();
-}
-
-static inline uint vector_length_in_bytes(const MachNode* n) {
-  const TypeVect* vt = n->bottom_type()->is_vect();
-  return vt->length_in_bytes();
-}
-
 static inline uint vector_length_in_bytes(const MachNode* use, MachOper* opnd) {
   uint def_idx = use->operand_index(opnd);
   Node* def = use->in(def_idx);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2080,19 +2080,6 @@ int vec_spill_helper(CodeBuffer *cbuf, bool do_size, bool is_load,
   return size+offset_size;
 }
 
-static inline jint replicate4_imm(int con, int width) {
-  // Load a constant of "width" (in bytes) and replicate it to fill 32bit.
-  assert(width == 1 || width == 2, "only byte or short types here");
-  int bit_width = width * 8;
-  jint val = con;
-  val &= (1 << bit_width) - 1;  // mask off sign bits
-  while(bit_width < 32) {
-    val |= (val << bit_width);
-    bit_width <<= 1;
-  }
-  return val;
-}
-
 static inline jlong replicate8_imm(int con, int width) {
   // Load a constant of "width" (in bytes) and replicate it to fill 64bit.
   assert(width == 1 || width == 2 || width == 4, "only byte, short or int types here");

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3268,1690 +3268,735 @@ instruct storeV(memory mem, vec src) %{
   ins_pipe( pipe_slow );
 %}
 
-// ====================LEGACY REPLICATE=======================================
-
-instruct Repl16B(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB src));
-  format %{ "movd    $dst,$src\n\t"
-            "punpcklbw $dst,$dst\n\t"
-            "pshuflw $dst,$dst,0x00\n\t"
-            "punpcklqdq $dst,$dst\t! replicate16B" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ punpcklbw($dst$$XMMRegister, $dst$$XMMRegister);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32B(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB src));
-  format %{ "movd    $dst,$src\n\t"
-            "punpcklbw $dst,$dst\n\t"
-            "pshuflw $dst,$dst,0x00\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate32B" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ punpcklbw($dst$$XMMRegister, $dst$$XMMRegister);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl64B(legVec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 64 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB src));
-  format %{ "movd    $dst,$src\n\t"
-            "punpcklbw $dst,$dst\n\t"
-            "pshuflw $dst,$dst,0x00\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate64B" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ punpcklbw($dst$$XMMRegister, $dst$$XMMRegister);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16B_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\t! replicate16B($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 1)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32B_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! lreplicate32B($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 1)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl64B_imm(legVec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 64 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate64B($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 1)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4S(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshuflw $dst,$dst,0x00\t! replicate4S" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4S_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "pshuflw $dst,$mem,0x00\t! replicate4S" %}
-  ins_encode %{
-    __ pshuflw($dst$$XMMRegister, $mem$$Address, 0x00);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8S(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshuflw $dst,$dst,0x00\n\t"
-            "punpcklqdq $dst,$dst\t! replicate8S" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8S_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 0 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "pshuflw $dst,$mem,0x00\n\t"
-            "punpcklqdq $dst,$dst\t! replicate8S" %}
-  ins_encode %{
-    __ pshuflw($dst$$XMMRegister, $mem$$Address, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8S_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\t! replicate8S($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 2)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16S(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshuflw $dst,$dst,0x00\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate16S" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16S_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "pshuflw $dst,$mem,0x00\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate16S" %}
-  ins_encode %{
-    __ pshuflw($dst$$XMMRegister, $mem$$Address, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16S_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate16S($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 2)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32S(legVec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshuflw $dst,$dst,0x00\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate32S" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32S_mem(legVec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "pshuflw $dst,$mem,0x00\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate32S" %}
-  ins_encode %{
-    __ pshuflw($dst$$XMMRegister, $mem$$Address, 0x00);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32S_imm(legVec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate32S($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 2)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4I(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshufd  $dst,$dst,0x00\t! replicate4I" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4I_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI (LoadI mem)));
-  format %{ "pshufd  $dst,$mem,0x00\t! replicate4I" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8I(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshufd  $dst,$dst,0x00\n\t"
-            "vinserti128_high $dst,$dst\t! replicate8I" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8I_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI (LoadI mem)));
-  format %{ "pshufd  $dst,$mem,0x00\n\t"
-            "vinserti128_high $dst,$dst\t! replicate8I" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16I(legVec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshufd  $dst,$dst,0x00\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate16I" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16I_mem(legVec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI (LoadI mem)));
-  format %{ "pshufd  $dst,$mem,0x00\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate16I" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4I_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate4I($con)\n\t"
-            "punpcklqdq $dst,$dst" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 4)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8I_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate8I($con)\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 4)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16I_imm(legVec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI con));
-  format %{ "movq    $dst,[$constantaddress]\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate16I($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 4)));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// Long could be loaded into xmm register directly from memory.
-instruct Repl2L_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 2 && !VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateL (LoadL mem)));
-  format %{ "movq    $dst,$mem\n\t"
-            "punpcklqdq $dst,$dst\t! replicate2L" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $mem$$Address);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// Replicate long (8 byte) scalar to be vector
-#ifdef _LP64
-instruct Repl4L(vec dst, rRegL src) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL src));
-  format %{ "movdq   $dst,$src\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate4L" %}
-  ins_encode %{
-    __ movdq($dst$$XMMRegister, $src$$Register);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L(legVec dst, rRegL src) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL src));
-  format %{ "movdq   $dst,$src\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate8L" %}
-  ins_encode %{
-    __ movdq($dst$$XMMRegister, $src$$Register);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-#else // _LP64
-instruct Repl4L(vec dst, eRegL src, vec tmp) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL src));
-  effect(TEMP dst, USE src, TEMP tmp);
-  format %{ "movdl   $dst,$src.lo\n\t"
-            "movdl   $tmp,$src.hi\n\t"
-            "punpckldq $dst,$tmp\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate4L" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
-    __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L(legVec dst, eRegL src, legVec tmp) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL src));
-  effect(TEMP dst, USE src, TEMP tmp);
-  format %{ "movdl   $dst,$src.lo\n\t"
-            "movdl   $tmp,$src.hi\n\t"
-            "punpckldq $dst,$tmp\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate8L" %}
-  ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
-    __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-#endif // _LP64
-
-instruct Repl4L_imm(vec dst, immL con) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate4L($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress($con));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L_imm(legVec dst, immL con) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate8L($con)" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $constantaddress($con));
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4L_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL (LoadL mem)));
-  format %{ "movq    $dst,$mem\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t! replicate4L" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $mem$$Address);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L_mem(legVec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL (LoadL mem)));
-  format %{ "movq    $dst,$mem\n\t"
-            "punpcklqdq $dst,$dst\n\t"
-            "vinserti128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate8L" %}
-  ins_encode %{
-    __ movq($dst$$XMMRegister, $mem$$Address);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl2F_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 2 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF (LoadF mem)));
-  format %{ "pshufd  $dst,$mem,0x00\t! replicate2F" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4F_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF (LoadF mem)));
-  format %{ "pshufd  $dst,$mem,0x00\t! replicate4F" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8F(vec dst, vlRegF src) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF src));
-  format %{ "pshufd  $dst,$src,0x00\n\t"
-            "vinsertf128_high $dst,$dst\t! replicate8F" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8F_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF (LoadF mem)));
-  format %{ "pshufd  $dst,$mem,0x00\n\t"
-            "vinsertf128_high $dst,$dst\t! replicate8F" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16F(legVec dst, vlRegF src) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF src));
-  format %{ "pshufd  $dst,$src,0x00\n\t"
-            "vinsertf128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate16F" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16F_mem(legVec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF (LoadF mem)));
-  format %{ "pshufd  $dst,$mem,0x00\n\t"
-            "vinsertf128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate16F" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl2F_zero(vec dst, immF0 zero) %{
-  predicate(n->as_Vector()->length() == 2);
-  match(Set dst (ReplicateF zero));
-  format %{ "xorps   $dst,$dst\t! replicate2F zero" %}
-  ins_encode %{
-    __ xorps($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl4F_zero(vec dst, immF0 zero) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (ReplicateF zero));
-  format %{ "xorps   $dst,$dst\t! replicate4F zero" %}
-  ins_encode %{
-    __ xorps($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl8F_zero(vec dst, immF0 zero) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 0);
-  match(Set dst (ReplicateF zero));
-  format %{ "vxorps  $dst,$dst,$dst\t! replicate8F zero" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vxorps($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl2D_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 2 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateD (LoadD mem)));
-  format %{ "pshufd  $dst,$mem,0x44\t! replicate2D" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x44);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4D(vec dst, vlRegD src) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateD src));
-  format %{ "pshufd  $dst,$src,0x44\n\t"
-            "vinsertf128_high $dst,$dst\t! replicate4D" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x44);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4D_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateD (LoadD mem)));
-  format %{ "pshufd  $dst,$mem,0x44\n\t"
-            "vinsertf128_high $dst,$dst\t! replicate4D" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x44);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8D(legVec dst, vlRegD src) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 0 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateD src));
-  format %{ "pshufd  $dst,$src,0x44\n\t"
-            "vinsertf128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate8D" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x44);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8D_mem(legVec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateD (LoadD mem)));
-  format %{ "pshufd  $dst,$mem,0x44\n\t"
-            "vinsertf128_high $dst,$dst\t"
-            "vinserti64x4 $dst,$dst,$dst,0x1\t! replicate8D" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x44);
-    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
-    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-// Replicate double (8 byte) scalar zero to be vector
-instruct Repl2D_zero(vec dst, immD0 zero) %{
-  predicate(n->as_Vector()->length() == 2);
-  match(Set dst (ReplicateD zero));
-  format %{ "xorpd   $dst,$dst\t! replicate2D zero" %}
-  ins_encode %{
-    __ xorpd($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl4D_zero(vec dst, immD0 zero) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 0);
-  match(Set dst (ReplicateD zero));
-  format %{ "vxorpd  $dst,$dst,$dst,vect256\t! replicate4D zero" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vxorpd($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// ====================GENERIC REPLICATE==========================================
+// ====================REPLICATE=======================================
 
 // Replicate byte scalar to be vector
-instruct Repl4B(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 4);
+instruct ReplB_reg(vec dst, rRegI src) %{
+  predicate((n->as_Vector()->length() <= 32) ||
+            (n->as_Vector()->length() == 64 && VM_Version::supports_avx512bw())); // AVX512BW for 512bit byte instructions
   match(Set dst (ReplicateB src));
-  format %{ "movd    $dst,$src\n\t"
-            "punpcklbw $dst,$dst\n\t"
-            "pshuflw $dst,$dst,0x00\t! replicate4B" %}
+  format %{ "replicateB $dst,$src" %}
   ins_encode %{
+    uint vlen = vector_length(this);
+    if (vlen == 64 || VM_Version::supports_avx512vlbw()) { // AVX512VL for <512bit operands
+      assert(VM_Version::supports_avx512bw(), "required");
+      int vlen_enc = vector_length_encoding(this);
+      __ evpbroadcastb($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else {
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ punpcklbw($dst$$XMMRegister, $dst$$XMMRegister);
+      __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+      if (vlen >= 16) {
+        __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+        if (vlen >= 32) {
+          assert(vlen == 32, "sanity"); // vlen == 64 && !AVX512BW is covered by ReplB_reg_leg
+          __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+        }
+      }
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplB_reg_leg(legVec dst, rRegI src) %{
+  predicate(n->as_Vector()->length() == 64 && !VM_Version::supports_avx512bw()); // AVX512BW for 512bit byte instructions
+  match(Set dst (ReplicateB src));
+  format %{ "replicateB $dst,$src" %}
+  ins_encode %{
+    assert(UseAVX > 2, "required");
     __ movdl($dst$$XMMRegister, $src$$Register);
     __ punpcklbw($dst$$XMMRegister, $dst$$XMMRegister);
     __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8B(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (ReplicateB src));
-  format %{ "movd    $dst,$src\n\t"
-            "punpcklbw $dst,$dst\n\t"
-            "pshuflw $dst,$dst,0x00\t! replicate8B" %}
+instruct ReplB_mem(vec dst, memory mem) %{
+  predicate((n->as_Vector()->length() <= 32 && VM_Version::supports_avx512vlbw()) || // AVX512VL for <512bit operands
+            (n->as_Vector()->length() == 64 && VM_Version::supports_avx512bw()));    // AVX512BW for 512bit byte instructions
+  match(Set dst (ReplicateB (LoadB mem)));
+  format %{ "replicateB $dst,$mem" %}
   ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ punpcklbw($dst$$XMMRegister, $dst$$XMMRegister);
-    __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+    assert(UseAVX > 2, "required");
+    int vector_len = vector_length_encoding(this);
+    __ vpbroadcastb($dst$$XMMRegister, $mem$$Address, vector_len);
   %}
   ins_pipe( pipe_slow );
 %}
 
-// Replicate byte scalar immediate to be vector by loading from const table.
-instruct Repl4B_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 4);
+instruct ReplB_imm(vec dst, immI con) %{
+  predicate((n->as_Vector()->length() <= 32) ||
+            (n->as_Vector()->length() == 64 && VM_Version::supports_avx512bw())); // AVX512BW for 512bit byte instructions
   match(Set dst (ReplicateB con));
-  format %{ "movdl   $dst,[$constantaddress]\t! replicate4B($con)" %}
+  format %{ "replicateB $dst,$con" %}
   ins_encode %{
-    __ movdl($dst$$XMMRegister, $constantaddress(replicate4_imm($con$$constant, 1)));
+    uint vlen = vector_length(this);
+    InternalAddress const_addr = $constantaddress(replicate8_imm($con$$constant, 1));
+    if (vlen == 4) {
+      __ movdl($dst$$XMMRegister, const_addr);
+    } else {
+      __ movq($dst$$XMMRegister, const_addr);
+      if (vlen >= 16) {
+        if (vlen == 64 || VM_Version::supports_avx512vlbw()) { // AVX512VL for <512bit operands
+          int vlen_enc = vector_length_encoding(this);
+          __ vpbroadcastb($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+        } else {
+          __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+          if (vlen >= 32) {
+             assert(vlen == 32, "sanity");// vlen == 64 && !AVX512BW is covered by ReplB_imm_leg
+            __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+          }
+        }
+      }
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8B_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 8);
+instruct ReplB_imm_leg(legVec dst, immI con) %{
+  predicate(n->as_Vector()->length() == 64 && !VM_Version::supports_avx512bw());
   match(Set dst (ReplicateB con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate8B($con)" %}
+  format %{ "replicateB $dst,$con" %}
   ins_encode %{
     __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 1)));
+    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
   ins_pipe( pipe_slow );
 %}
 
 // Replicate byte scalar zero to be vector
-instruct Repl4B_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 4);
+instruct ReplB_zero(vec dst, immI0 zero) %{
   match(Set dst (ReplicateB zero));
-  format %{ "pxor    $dst,$dst\t! replicate4B zero" %}
+  format %{ "replicateB $dst,$zero" %}
   ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    uint vlen = vector_length(this);
+    if (vlen <= 16) {
+      __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    } else {
+      // Use vpxor since AVX512F does not have 512bit vxorpd (requires AVX512DQ).
+      int vlen_enc = vector_length_encoding(this);
+      __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+    }
   %}
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl8B_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (ReplicateB zero));
-  format %{ "pxor    $dst,$dst\t! replicate8B zero" %}
-  ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
+// ====================ReplicateS=======================================
 
-instruct Repl16B_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 16);
-  match(Set dst (ReplicateB zero));
-  format %{ "pxor    $dst,$dst\t! replicate16B zero" %}
-  ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl32B_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 32);
-  match(Set dst (ReplicateB zero));
-  format %{ "vpxor   $dst,$dst,$dst\t! replicate32B zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 256-bit (AVX2 will have it).
-    int vector_len = 1;
-    __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Replicate char/short (2 byte) scalar to be vector
-instruct Repl2S(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplS_reg(vec dst, rRegI src) %{
+  predicate((n->as_Vector()->length() <= 16) ||
+            (n->as_Vector()->length() == 32 && VM_Version::supports_avx512bw())); // AVX512BW for 512bit instructions on shorts
   match(Set dst (ReplicateS src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshuflw $dst,$dst,0x00\t! replicate2S" %}
+  format %{ "replicateS $dst,$src" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    if (vlen == 32 || VM_Version::supports_avx512vlbw()) { // AVX512VL for <512bit operands
+      assert(VM_Version::supports_avx512bw(), "required");
+      int vlen_enc = vector_length_encoding(this);
+      __ evpbroadcastw($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else {
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+      if (vlen >= 8) {
+        __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+        if (vlen >= 16) {
+          assert(vlen == 16, "sanity"); // vlen == 32 && !AVX512BW is covered by ReplS_reg_leg
+          __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+        }
+      }
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplS_reg_leg(legVec dst, rRegI src) %{
+  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512bw());
+  match(Set dst (ReplicateS src));
+  format %{ "replicateS $dst,$src" %}
   ins_encode %{
     __ movdl($dst$$XMMRegister, $src$$Register);
     __ pshuflw($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
-  ins_pipe( fpu_reg_reg );
+  ins_pipe( pipe_slow );
 %}
 
-// Replicate char/short (2 byte) scalar immediate to be vector by loading from const table.
-instruct Repl2S_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 2);
-  match(Set dst (ReplicateS con));
-  format %{ "movdl   $dst,[$constantaddress]\t! replicate2S($con)" %}
+instruct ReplS_mem(vec dst, memory mem) %{
+  predicate((n->as_Vector()->length() >= 4  &&
+             n->as_Vector()->length() <= 16 && VM_Version::supports_avx()) ||
+            (n->as_Vector()->length() == 32 && VM_Version::supports_avx512bw())); // AVX512BW for 512bit instructions on shorts
+  match(Set dst (ReplicateS (LoadS mem)));
+  format %{ "replicateS $dst,$mem" %}
   ins_encode %{
-    __ movdl($dst$$XMMRegister, $constantaddress(replicate4_imm($con$$constant, 2)));
+    uint vlen = vector_length(this);
+    if (vlen == 32 || VM_Version::supports_avx512vlbw()) { // AVX512VL for <512bit operands
+      assert(VM_Version::supports_avx512bw(), "required");
+      int vlen_enc = vector_length_encoding(this);
+      __ vpbroadcastw($dst$$XMMRegister, $mem$$Address, vlen_enc);
+    } else {
+      __ pshuflw($dst$$XMMRegister, $mem$$Address, 0x00);
+      if (vlen >= 8) {
+        __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+        if (vlen >= 16) {
+          assert(vlen == 16, "sanity"); // vlen == 32 && !AVX512BW is covered by ReplS_mem_leg
+          __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+        }
+      }
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplS_mem_leg(legVec dst, memory mem) %{
+  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512bw());
+  match(Set dst (ReplicateS (LoadS mem)));
+  format %{ "replicateS $dst,$mem" %}
+  ins_encode %{
+    __ pshuflw($dst$$XMMRegister, $mem$$Address, 0x00);
+    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplS_imm(vec dst, immI con) %{
+  predicate((n->as_Vector()->length() <= 16) ||
+            (n->as_Vector()->length() == 32 && VM_Version::supports_avx512bw())); // AVX512BW for 512bit instructions on shorts
+  match(Set dst (ReplicateS con));
+  format %{ "replicateS $dst,$con" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    InternalAddress constaddr = $constantaddress(replicate8_imm($con$$constant, 2));
+    if (vlen == 2) {
+      __ movdl($dst$$XMMRegister, constaddr);
+    } else {
+      __ movq($dst$$XMMRegister, constaddr);
+      if (vlen == 32 || VM_Version::supports_avx512vlbw() ) { // AVX512VL for <512bit operands
+        assert(VM_Version::supports_avx512bw(), "required");
+        int vlen_enc = vector_length_encoding(this);
+        __ vpbroadcastw($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+      } else {
+        __ movq($dst$$XMMRegister, constaddr);
+        __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+        if (vlen >= 16) {
+          assert(vlen == 16, "sanity"); // vlen == 32 && !AVX512BW is covered by ReplS_imm_leg
+          __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+        }
+      }
+    }
   %}
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4S_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 4);
+instruct ReplS_imm_leg(legVec dst, immI con) %{
+  predicate(n->as_Vector()->length() == 32 && !VM_Version::supports_avx512bw());
   match(Set dst (ReplicateS con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate4S($con)" %}
+  format %{ "replicateS $dst,$con" %}
   ins_encode %{
     __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 2)));
+    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
-  ins_pipe( fpu_reg_reg );
+  ins_pipe( pipe_slow );
 %}
 
-// Replicate char/short (2 byte) scalar zero to be vector
-instruct Repl2S_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplS_zero(vec dst, immI0 zero) %{
   match(Set dst (ReplicateS zero));
-  format %{ "pxor    $dst,$dst\t! replicate2S zero" %}
+  format %{ "replicateS $dst,$zero" %}
   ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    uint vlen = vector_length(this);
+    if (vlen <= 8) {
+      __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    } else {
+      int vlen_enc = vector_length_encoding(this);
+      __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+    }
   %}
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4S_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (ReplicateS zero));
-  format %{ "pxor    $dst,$dst\t! replicate4S zero" %}
-  ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
+// ====================ReplicateI=======================================
 
-instruct Repl8S_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (ReplicateS zero));
-  format %{ "pxor    $dst,$dst\t! replicate8S zero" %}
-  ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl16S_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 16);
-  match(Set dst (ReplicateS zero));
-  format %{ "vpxor   $dst,$dst,$dst\t! replicate16S zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 256-bit (AVX2 will have it).
-    int vector_len = 1;
-    __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Replicate integer (4 byte) scalar to be vector
-instruct Repl2I(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplI_reg(vec dst, rRegI src) %{
+  predicate((n->as_Vector()->length() <= 8) ||
+            (n->as_Vector()->length() == 16 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateI src));
-  format %{ "movd    $dst,$src\n\t"
-            "pshufd  $dst,$dst,0x00\t! replicate2I" %}
+  format %{ "replicateI $dst,$src" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vlen_enc = vector_length_encoding(this);
+      __ evpbroadcastd($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else {
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+      if (vlen >= 8) {
+        assert(vlen == 8, "sanity"); // vlen == 16 && !AVX512VL is covered by ReplI_reg_leg
+        __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+      }
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplI_reg_leg(legVec dst, rRegI src) %{
+  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateI src));
+  format %{ "replicateI  $dst,$src" %}
   ins_encode %{
     __ movdl($dst$$XMMRegister, $src$$Register);
     __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
-  ins_pipe( fpu_reg_reg );
+  ins_pipe( pipe_slow );
 %}
 
-// Integer could be loaded into xmm register directly from memory.
-instruct Repl2I_mem(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplI_mem(vec dst, memory mem) %{
+  predicate((n->as_Vector()->length() <= 8  && VM_Version::supports_avx()) ||
+            (n->as_Vector()->length() == 16 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateI (LoadI mem)));
-  format %{ "movd    $dst,$mem\n\t"
-            "pshufd  $dst,$dst,0x00\t! replicate2I" %}
+  format %{ "replicateI $dst,$mem" %}
   ins_encode %{
-    __ movdl($dst$$XMMRegister, $mem$$Address);
-    __ pshufd($dst$$XMMRegister, $dst$$XMMRegister, 0x00);
+    uint vlen = vector_length(this);
+    if (vlen <= 4) {
+      __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vector_len = vector_length_encoding(this);
+      __ vpbroadcastd($dst$$XMMRegister, $mem$$Address, vector_len);
+    } else {
+      assert(vlen == 8, "sanity"); // vlen == 16 && !AVX512VL is covered by ReplI_mem_leg
+      __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
+      __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
   %}
-  ins_pipe( fpu_reg_reg );
+  ins_pipe( pipe_slow );
 %}
 
-// Replicate integer (4 byte) scalar immediate to be vector by loading from const table.
-instruct Repl2I_imm(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplI_mem_leg(legVec dst, memory mem) %{
+  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateI (LoadI mem)));
+  format %{ "replicateI $dst,$mem" %}
+  ins_encode %{
+    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplI_imm(vec dst, immI con) %{
+  predicate((n->as_Vector()->length() <= 8) ||
+            (n->as_Vector()->length() == 16 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateI con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate2I($con)" %}
+  format %{ "replicateI $dst,$con" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    InternalAddress constaddr = $constantaddress(replicate8_imm($con$$constant, 4));
+    if (vlen == 2) {
+      __ movq($dst$$XMMRegister, constaddr);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vector_len = vector_length_encoding(this);
+      __ movq($dst$$XMMRegister, constaddr);
+      __ vpbroadcastd($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
+    } else {
+      __ movq($dst$$XMMRegister, constaddr);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+      if (vlen >= 8) {
+        assert(vlen == 8, "sanity");
+        __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+      }
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplI_imm_leg(legVec dst, immI con) %{
+  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateI con));
+  format %{ "replicateI $dst,$con" %}
   ins_encode %{
     __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 4)));
+    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
-  ins_pipe( fpu_reg_reg );
+  ins_pipe( pipe_slow );
 %}
 
 // Replicate integer (4 byte) scalar zero to be vector
-instruct Repl2I_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplI_zero(vec dst, immI0 zero) %{
   match(Set dst (ReplicateI zero));
-  format %{ "pxor    $dst,$dst\t! replicate2I" %}
+  format %{ "replicateI $dst,$zero" %}
   ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    uint vlen = vector_length(this);
+    if (vlen <= 4) {
+      __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    } else {
+      int vlen_enc = vector_length_encoding(this);
+      __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+    }
   %}
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4I_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (ReplicateI zero));
-  format %{ "pxor    $dst,$dst\t! replicate4I zero)" %}
-  ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
+// ====================ReplicateL=======================================
 
-instruct Repl8I_zero(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 8);
-  match(Set dst (ReplicateI zero));
-  format %{ "vpxor   $dst,$dst,$dst\t! replicate8I zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 256-bit (AVX2 will have it).
-    int vector_len = 1;
-    __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Replicate long (8 byte) scalar to be vector
 #ifdef _LP64
-instruct Repl2L(vec dst, rRegL src) %{
-  predicate(n->as_Vector()->length() == 2);
+// Replicate long (8 byte) scalar to be vector
+instruct ReplL_reg(vec dst, rRegL src) %{
+  predicate((n->as_Vector()->length() <= 4) ||
+            (n->as_Vector()->length() == 8 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateL src));
-  format %{ "movdq   $dst,$src\n\t"
-            "punpcklqdq $dst,$dst\t! replicate2L" %}
+  format %{ "replicateL $dst,$src" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    if (vlen == 2) {
+      __ movdq($dst$$XMMRegister, $src$$Register);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vlen_enc = vector_length_encoding(this);
+      __ evpbroadcastq($dst$$XMMRegister, $src$$Register, vlen_enc);
+    } else {
+      assert(vlen == 4, "sanity"); // vlen == 8 && !AVX512VL is covered by ReplL_reg_leg
+      __ movdq($dst$$XMMRegister, $src$$Register);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+      __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplL_reg_leg(legVec dst, rRegL src) %{
+  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateL src));
+  format %{ "replicateL $dst,$src" %}
   ins_encode %{
     __ movdq($dst$$XMMRegister, $src$$Register);
     __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
   ins_pipe( pipe_slow );
 %}
 #else // _LP64
-instruct Repl2L(vec dst, eRegL src, vec tmp) %{
-  predicate(n->as_Vector()->length() == 2);
+// Replicate long (8 byte) scalar to be vector
+instruct ReplL_reg(vec dst, eRegL src, vec tmp) %{
+  predicate(n->as_Vector()->length() <= 4);
   match(Set dst (ReplicateL src));
   effect(TEMP dst, USE src, TEMP tmp);
-  format %{ "movdl   $dst,$src.lo\n\t"
-            "movdl   $tmp,$src.hi\n\t"
-            "punpckldq $dst,$tmp\n\t"
-            "punpcklqdq $dst,$dst\t! replicate2L"%}
+  format %{ "replicateL $dst,$src" %}
   ins_encode %{
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
-    __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
-    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    uint vlen = vector_length(this);
+    if (vlen == 2) {
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
+      __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vector_len = Assembler::AVX_256bit;
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
+      __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
+      __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
+    } else {
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
+      __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+      __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplL_reg_leg(legVec dst, eRegL src, legVec tmp) %{
+  predicate(n->as_Vector()->length() == 8);
+  match(Set dst (ReplicateL src));
+  effect(TEMP dst, USE src, TEMP tmp);
+  format %{ "replicateL $dst,$src" %}
+  ins_encode %{
+    if (VM_Version::supports_avx512vl()) {
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
+      __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+      __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+      __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
+    } else {
+      int vector_len = Assembler::AVX_512bit;
+      __ movdl($dst$$XMMRegister, $src$$Register);
+      __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
+      __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
+      __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 #endif // _LP64
+
+instruct ReplL_mem(vec dst, memory mem) %{
+  predicate((n->as_Vector()->length() <= 4) ||
+            (n->as_Vector()->length() == 8 && VM_Version::supports_avx512vl()));
+  match(Set dst (ReplicateL (LoadL mem)));
+  format %{ "replicateL $dst,$mem" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    if (vlen == 2) {
+      __ movq($dst$$XMMRegister, $mem$$Address);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vlen_enc = vector_length_encoding(this);
+      __ vpbroadcastq($dst$$XMMRegister, $mem$$Address, vlen_enc);
+    } else {
+      assert(vlen == 4, "sanity"); // vlen == 8 && !AVX512VL is covered by ReplL_mem_leg
+      __ movq($dst$$XMMRegister, $mem$$Address);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+      __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplL_mem_leg(legVec dst, memory mem) %{
+  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateL (LoadL mem)));
+  format %{ "replicateL $dst,$mem" %}
+  ins_encode %{
+    __ movq($dst$$XMMRegister, $mem$$Address);
+    __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
+  %}
+  ins_pipe( pipe_slow );
+%}
 
 // Replicate long (8 byte) scalar immediate to be vector by loading from const table.
-instruct Repl2L_imm(vec dst, immL con) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplL_imm(vec dst, immL con) %{
+  predicate((n->as_Vector()->length() <= 4) ||
+            (n->as_Vector()->length() == 8 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateL con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "punpcklqdq $dst,$dst\t! replicate2L($con)" %}
+  format %{ "replicateL $dst,$con" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    InternalAddress const_addr = $constantaddress($con);
+    if (vlen == 2) {
+      __ movq($dst$$XMMRegister, const_addr);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vlen_enc = vector_length_encoding(this);
+      __ movq($dst$$XMMRegister, const_addr);
+      __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+    } else {
+      assert(vlen == 4, "sanity"); // vlen == 8 && !AVX512VL is covered by ReplL_imm_leg
+      __ movq($dst$$XMMRegister, const_addr);
+      __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+      __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplL_imm_leg(legVec dst, immL con) %{
+  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateL con));
+  format %{ "replicateL $dst,$con" %}
   ins_encode %{
     __ movq($dst$$XMMRegister, $constantaddress($con));
     __ punpcklqdq($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
   ins_pipe( pipe_slow );
 %}
 
-// Replicate long (8 byte) scalar zero to be vector
-instruct Repl2L_zero(vec dst, immL0 zero) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplL_zero(vec dst, immL0 zero) %{
   match(Set dst (ReplicateL zero));
-  format %{ "pxor    $dst,$dst\t! replicate2L zero" %}
+  format %{ "replicateL $dst,$zero" %}
   ins_encode %{
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    int vlen = vector_length(this);
+    if (vlen == 2) {
+      __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    } else {
+      int vlen_enc = vector_length_encoding(this);
+      __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc);
+    }
   %}
   ins_pipe( fpu_reg_reg );
 %}
 
-instruct Repl4L_zero(vec dst, immL0 zero) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (ReplicateL zero));
-  format %{ "vpxor   $dst,$dst,$dst\t! replicate4L zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 256-bit (AVX2 will have it).
-    int vector_len = 1;
-    __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
+// ====================ReplicateF=======================================
 
-// Replicate float (4 byte) scalar to be vector
-instruct Repl2F(vec dst, vlRegF src) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplF_reg(vec dst, vlRegF src) %{
+  predicate((n->as_Vector()->length() <= 8) ||
+            (n->as_Vector()->length() == 16 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateF src));
-  format %{ "pshufd  $dst,$dst,0x00\t! replicate2F" %}
+  format %{ "replicateF $dst,$src" %}
   ins_encode %{
-    __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl4F(vec dst, vlRegF src) %{
-  predicate(n->as_Vector()->length() == 4);
-  match(Set dst (ReplicateF src));
-  format %{ "pshufd  $dst,$dst,0x00\t! replicate4F" %}
-  ins_encode %{
-    __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
+    uint vlen = vector_length(this);
+    if (vlen <= 4) {
+      __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vector_len = vector_length_encoding(this);
+      __ vpbroadcastss($dst$$XMMRegister, $src$$XMMRegister, vector_len);
+    } else {
+      assert(vlen == 8, "sanity"); // vlen == 16 && !AVX512VL is covered by ReplF_reg_leg
+      __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
+      __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
+
+instruct ReplF_reg_leg(legVec dst, vlRegF src) %{
+  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateF src));
+  format %{ "replicateF $dst,$src" %}
+  ins_encode %{
+    __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x00);
+    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplF_mem(vec dst, memory mem) %{
+  predicate((n->as_Vector()->length() <= 8  && VM_Version::supports_avx()) ||
+            (n->as_Vector()->length() == 16 && VM_Version::supports_avx512vl()));
+  match(Set dst (ReplicateF (LoadF mem)));
+  format %{ "replicateF $dst,$mem" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    if (vlen <= 4) {
+      __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vector_len = vector_length_encoding(this);
+      __ vpbroadcastss($dst$$XMMRegister, $mem$$Address, vector_len);
+    } else {
+      assert(vlen == 8, "sanity"); // vlen == 16 && !AVX512VL is covered by ReplF_mem_leg
+      __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
+      __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplF_mem_leg(legVec dst, memory mem) %{
+  predicate(n->as_Vector()->length() == 16 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateF (LoadF mem)));
+  format %{ "replicateF $dst,$mem" %}
+  ins_encode %{
+    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x00);
+    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplF_zero(vec dst, immF0 zero) %{
+  match(Set dst (ReplicateF zero));
+  format %{ "replicateF $dst,$zero" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    if (vlen <= 4) {
+      __ xorps($dst$$XMMRegister, $dst$$XMMRegister);
+    } else {
+      int vlen_enc = vector_length_encoding(this);
+      __ vpxor($dst$$XMMRegister,$dst$$XMMRegister, $dst$$XMMRegister, vlen_enc); // 512bit vxorps requires AVX512DQ
+    }
+  %}
+  ins_pipe( fpu_reg_reg );
+%}
+
+// ====================ReplicateD=======================================
 
 // Replicate double (8 bytes) scalar to be vector
-instruct Repl2D(vec dst, vlRegD src) %{
-  predicate(n->as_Vector()->length() == 2);
+instruct ReplD_reg(vec dst, vlRegD src) %{
+  predicate((n->as_Vector()->length() <= 4) ||
+            (n->as_Vector()->length() == 8 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateD src));
-  format %{ "pshufd  $dst,$src,0x44\t! replicate2D" %}
+  format %{ "replicateD $dst,$src" %}
+  ins_encode %{
+    uint vlen = vector_length(this);
+    if (vlen == 2) {
+      __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x44);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vector_len = vector_length_encoding(this);
+      __ vpbroadcastsd($dst$$XMMRegister, $src$$XMMRegister, vector_len);
+    } else {
+      assert(vlen == 4, "sanity"); // vlen == 8 && !AVX512VL is covered by ReplD_reg_leg
+      __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x44);
+      __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct ReplD_reg_leg(legVec dst, vlRegD src) %{
+  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
+  match(Set dst (ReplicateD src));
+  format %{ "replicateD $dst,$src" %}
   ins_encode %{
     __ pshufd($dst$$XMMRegister, $src$$XMMRegister, 0x44);
+    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
   ins_pipe( pipe_slow );
 %}
 
-// ====================EVEX REPLICATE=============================================
-
-instruct Repl4B_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB (LoadB mem)));
-  format %{ "vpbroadcastb  $dst,$mem\t! replicate4B" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ vpbroadcastb($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8B_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB (LoadB mem)));
-  format %{ "vpbroadcastb  $dst,$mem\t! replicate8B" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ vpbroadcastb($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16B_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB src));
-  format %{ "evpbroadcastb $dst,$src\t! replicate16B" %}
-  ins_encode %{
-   int vector_len = 0;
-    __ evpbroadcastb($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16B_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB (LoadB mem)));
-  format %{ "vpbroadcastb  $dst,$mem\t! replicate16B" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ vpbroadcastb($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32B_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB src));
-  format %{ "evpbroadcastb $dst,$src\t! replicate32B" %}
-  ins_encode %{
-   int vector_len = 1;
-    __ evpbroadcastb($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32B_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB (LoadB mem)));
-  format %{ "vpbroadcastb  $dst,$mem\t! replicate32B" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastb($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl64B_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 64 && UseAVX > 2 && VM_Version::supports_avx512bw());
-  match(Set dst (ReplicateB src));
-  format %{ "evpbroadcastb $dst,$src\t! upper replicate64B" %}
-  ins_encode %{
-   int vector_len = 2;
-    __ evpbroadcastb($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl64B_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 64 && UseAVX > 2 && VM_Version::supports_avx512bw());
-  match(Set dst (ReplicateB (LoadB mem)));
-  format %{ "vpbroadcastb  $dst,$mem\t! replicate64B" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastb($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16B_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastb $dst,$dst\t! replicate16B" %}
-  ins_encode %{
-   int vector_len = 0;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 1)));
-    __ vpbroadcastb($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32B_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateB con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastb $dst,$dst\t! replicate32B" %}
-  ins_encode %{
-   int vector_len = 1;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 1)));
-    __ vpbroadcastb($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl64B_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 64 && UseAVX > 2 && VM_Version::supports_avx512bw());
-  match(Set dst (ReplicateB con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastb $dst,$dst\t! upper replicate64B" %}
-  ins_encode %{
-   int vector_len = 2;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 1)));
-    __ vpbroadcastb($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl64B_zero_evex(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 64 && UseAVX > 2);
-  match(Set dst (ReplicateB zero));
-  format %{ "vpxor   $dst k0,$dst,$dst\t! replicate64B zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 512-bit (EVEX will have it).
-    int vector_len = 2;
-    __ vpxor($dst$$XMMRegister,$dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl4S_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS src));
-  format %{ "evpbroadcastw $dst,$src\t! replicate4S" %}
-  ins_encode %{
-   int vector_len = 0;
-    __ evpbroadcastw($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4S_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "vpbroadcastw  $dst,$mem\t! replicate4S" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ vpbroadcastw($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8S_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS src));
-  format %{ "evpbroadcastw $dst,$src\t! replicate8S" %}
-  ins_encode %{
-   int vector_len = 0;
-    __ evpbroadcastw($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8S_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "vpbroadcastw  $dst,$mem\t! replicate8S" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ vpbroadcastw($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16S_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS src));
-  format %{ "evpbroadcastw $dst,$src\t! replicate16S" %}
-  ins_encode %{
-   int vector_len = 1;
-    __ evpbroadcastw($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16S_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "vpbroadcastw  $dst,$mem\t! replicate16S" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastw($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32S_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512bw());
-  match(Set dst (ReplicateS src));
-  format %{ "evpbroadcastw $dst,$src\t! replicate32S" %}
-  ins_encode %{
-   int vector_len = 2;
-    __ evpbroadcastw($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32S_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512bw());
-  match(Set dst (ReplicateS (LoadS mem)));
-  format %{ "vpbroadcastw  $dst,$mem\t! replicate32S" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastw($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8S_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastw $dst,$dst\t! replicate8S" %}
-  ins_encode %{
-   int vector_len = 0;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 2)));
-    __ vpbroadcastw($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16S_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2 && VM_Version::supports_avx512vlbw());
-  match(Set dst (ReplicateS con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastw $dst,$dst\t! replicate16S" %}
-  ins_encode %{
-   int vector_len = 1;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 2)));
-    __ vpbroadcastw($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32S_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 32 && UseAVX > 2 && VM_Version::supports_avx512bw());
-  match(Set dst (ReplicateS con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastw $dst,$dst\t! replicate32S" %}
-  ins_encode %{
-   int vector_len = 2;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 2)));
-    __ vpbroadcastw($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl32S_zero_evex(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 32 && UseAVX > 2);
-  match(Set dst (ReplicateS zero));
-  format %{ "vpxor   $dst k0,$dst,$dst\t! replicate32S zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 512-bit (EVEX will have it).
-    int vector_len = 2;
-    __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl4I_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI src));
-  format %{ "evpbroadcastd  $dst,$src\t! replicate4I" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ evpbroadcastd($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4I_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI (LoadI mem)));
-  format %{ "vpbroadcastd  $dst,$mem\t! replicate4I" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ vpbroadcastd($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8I_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI src));
-  format %{ "evpbroadcastd  $dst,$src\t! replicate8I" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ evpbroadcastd($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8I_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI (LoadI mem)));
-  format %{ "vpbroadcastd  $dst,$mem\t! replicate8I" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastd($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16I_evex(vec dst, rRegI src) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
-  match(Set dst (ReplicateI src));
-  format %{ "evpbroadcastd  $dst,$src\t! replicate16I" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ evpbroadcastd($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16I_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
-  match(Set dst (ReplicateI (LoadI mem)));
-  format %{ "vpbroadcastd  $dst,$mem\t! replicate16I" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastd($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4I_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate8I($con)\n\t"
-            "vpbroadcastd  $dst,$dst\t! replicate4I" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 4)));
-    __ vpbroadcastd($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8I_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateI con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate8I($con)\n\t"
-            "vpbroadcastd  $dst,$dst\t! replicate8I" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 4)));
-    __ vpbroadcastd($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16I_imm_evex(vec dst, immI con) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
-  match(Set dst (ReplicateI con));
-  format %{ "movq    $dst,[$constantaddress]\t! replicate16I($con)\n\t"
-            "vpbroadcastd  $dst,$dst\t! replicate16I" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ movq($dst$$XMMRegister, $constantaddress(replicate8_imm($con$$constant, 4)));
-    __ vpbroadcastd($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16I_zero_evex(vec dst, immI0 zero) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
-  match(Set dst (ReplicateI zero));
-  format %{ "vpxor   $dst k0,$dst,$dst\t! replicate16I zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 512-bit (AVX2 will have it).
-    int vector_len = 2;
-    __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-// Replicate long (8 byte) scalar to be vector
-#ifdef _LP64
-instruct Repl4L_evex(vec dst, rRegL src) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL src));
-  format %{ "evpbroadcastq  $dst,$src\t! replicate4L" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ evpbroadcastq($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L_evex(vec dst, rRegL src) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
-  match(Set dst (ReplicateL src));
-  format %{ "evpbroadcastq  $dst,$src\t! replicate8L" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ evpbroadcastq($dst$$XMMRegister, $src$$Register, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-#else // _LP64
-instruct Repl4L_evex(vec dst, eRegL src, regD tmp) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL src));
-  effect(TEMP dst, USE src, TEMP tmp);
-  format %{ "movdl   $dst,$src.lo\n\t"
-            "movdl   $tmp,$src.hi\n\t"
-            "punpckldq $dst,$tmp\n\t"
-            "vpbroadcastq  $dst,$dst\t! replicate4L" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
-    __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
-    __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L_evex(legVec dst, eRegL src, legVec tmp) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
-  match(Set dst (ReplicateL src));
-  effect(TEMP dst, USE src, TEMP tmp);
-  format %{ "movdl   $dst,$src.lo\n\t"
-            "movdl   $tmp,$src.hi\n\t"
-            "punpckldq $dst,$tmp\n\t"
-            "vpbroadcastq  $dst,$dst\t! replicate8L" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ movdl($dst$$XMMRegister, $src$$Register);
-    __ movdl($tmp$$XMMRegister, HIGH_FROM_LOW($src$$Register));
-    __ punpckldq($dst$$XMMRegister, $tmp$$XMMRegister);
-    __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-#endif // _LP64
-
-instruct Repl4L_imm_evex(vec dst, immL con) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastq  $dst,$dst\t! replicate4L" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ movq($dst$$XMMRegister, $constantaddress($con));
-    __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L_imm_evex(vec dst, immL con) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
-  match(Set dst (ReplicateL con));
-  format %{ "movq    $dst,[$constantaddress]\n\t"
-            "vpbroadcastq  $dst,$dst\t! replicate8L" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ movq($dst$$XMMRegister, $constantaddress($con));
-    __ vpbroadcastq($dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl2L_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 2 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL (LoadL mem)));
-  format %{ "vpbroadcastd  $dst,$mem\t! replicate2L" %}
-  ins_encode %{
-    int vector_len = 0;
-    __ vpbroadcastq($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4L_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateL (LoadL mem)));
-  format %{ "vpbroadcastd  $dst,$mem\t! replicate4L" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastq($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
-  match(Set dst (ReplicateL (LoadL mem)));
-  format %{ "vpbroadcastd  $dst,$mem\t! replicate8L" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastq($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8L_zero_evex(vec dst, immL0 zero) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
-  match(Set dst (ReplicateL zero));
-  format %{ "vpxor   $dst k0,$dst,$dst\t! replicate8L zero" %}
-  ins_encode %{
-    // Use vxorpd since AVX does not have vpxor for 512-bit (EVEX will have it).
-    int vector_len = 2;
-    __ vpxor($dst$$XMMRegister,$dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl8F_evex(vec dst, regF src) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF src));
-  format %{ "vpbroadcastss $dst,$src\t! replicate8F" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastss($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8F_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateF (LoadF mem)));
-  format %{ "vbroadcastss  $dst,$mem\t! replicate8F" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastss($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16F_evex(vec dst, regF src) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
-  match(Set dst (ReplicateF src));
-  format %{ "vpbroadcastss $dst,$src\t! replicate16F" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastss($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16F_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
-  match(Set dst (ReplicateF (LoadF mem)));
-  format %{ "vbroadcastss  $dst,$mem\t! replicate16F" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastss($dst$$XMMRegister, $mem$$Address, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl16F_zero_evex(vec dst, immF0 zero) %{
-  predicate(n->as_Vector()->length() == 16 && UseAVX > 2);
-  match(Set dst (ReplicateF zero));
-  format %{ "vpxor  $dst k0,$dst,$dst\t! replicate16F zero" %}
-  ins_encode %{
-    // Use vpxor in place of vxorps since EVEX has a constriant on dq for vxorps: this is a 512-bit operation
-    int vector_len = 2;
-    __ vpxor($dst$$XMMRegister,$dst$$XMMRegister, $dst$$XMMRegister, vector_len);
-  %}
-  ins_pipe( fpu_reg_reg );
-%}
-
-instruct Repl4D_evex(vec dst, regD src) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
-  match(Set dst (ReplicateD src));
-  format %{ "vpbroadcastsd $dst,$src\t! replicate4D" %}
-  ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastsd($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl4D_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 4 && UseAVX > 2 && VM_Version::supports_avx512vl());
+instruct ReplD_mem(vec dst, memory mem) %{
+  predicate((n->as_Vector()->length() <= 4 && VM_Version::supports_avx()) ||
+            (n->as_Vector()->length() == 8 && VM_Version::supports_avx512vl()));
   match(Set dst (ReplicateD (LoadD mem)));
-  format %{ "vbroadcastsd  $dst,$mem\t! replicate4D" %}
+  format %{ "replicateD $dst,$mem" %}
   ins_encode %{
-    int vector_len = 1;
-    __ vpbroadcastsd($dst$$XMMRegister, $mem$$Address, vector_len);
+    uint vlen = vector_length(this);
+    if (vlen == 2) {
+      __ pshufd($dst$$XMMRegister, $mem$$Address, 0x44);
+    } else if (VM_Version::supports_avx512vl()) { // AVX512VL for <512bit operands
+      int vector_len = vector_length_encoding(this);
+      __ vpbroadcastsd($dst$$XMMRegister, $mem$$Address, vector_len);
+    } else {
+      assert(vlen == 4, "sanity"); // vlen == 8 && !AVX512VL is covered by ReplD_mem_leg
+      __ pshufd($dst$$XMMRegister, $mem$$Address, 0x44);
+      __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    }
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8D_evex(vec dst, regD src) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
-  match(Set dst (ReplicateD src));
-  format %{ "vpbroadcastsd $dst,$src\t! replicate8D" %}
-  ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastsd($dst$$XMMRegister, $src$$XMMRegister, vector_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
-instruct Repl8D_mem_evex(vec dst, memory mem) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
+instruct ReplD_mem_leg(legVec dst, memory mem) %{
+  predicate(n->as_Vector()->length() == 8 && !VM_Version::supports_avx512vl());
   match(Set dst (ReplicateD (LoadD mem)));
-  format %{ "vbroadcastsd  $dst,$mem\t! replicate8D" %}
+  format %{ "replicateD $dst,$mem" %}
   ins_encode %{
-    int vector_len = 2;
-    __ vpbroadcastsd($dst$$XMMRegister, $mem$$Address, vector_len);
+    __ pshufd($dst$$XMMRegister, $mem$$Address, 0x44);
+    __ vinsertf128_high($dst$$XMMRegister, $dst$$XMMRegister);
+    __ vinserti64x4($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, 0x1);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct Repl8D_zero_evex(vec dst, immD0 zero) %{
-  predicate(n->as_Vector()->length() == 8 && UseAVX > 2);
+instruct ReplD_zero(vec dst, immD0 zero) %{
   match(Set dst (ReplicateD zero));
-  format %{ "vpxor  $dst k0,$dst,$dst,vect512\t! replicate8D zero" %}
+  format %{ "replicateD $dst,$zero" %}
   ins_encode %{
-    // Use vpxor in place of vxorpd since EVEX has a constriant on dq for vxorpd: this is a 512-bit operation
-    int vector_len = 2;
-    __ vpxor($dst$$XMMRegister,$dst$$XMMRegister, $dst$$XMMRegister, vector_len);
+    uint vlen = vector_length(this);
+    if (vlen == 2) {
+      __ xorpd($dst$$XMMRegister, $dst$$XMMRegister);
+    } else {
+      int vlen_enc = vector_length_encoding(this);
+      __ vpxor($dst$$XMMRegister, $dst$$XMMRegister, $dst$$XMMRegister, vlen_enc); // 512bit vxorps requires AVX512DQ
+    }
   %}
   ins_pipe( fpu_reg_reg );
 %}


### PR DESCRIPTION
[Backport] 8235825: C2: Merge AD instructions for Replicate nodes

Summary: Backport VectorAPI 8235825: C2: Merge AD instructions for Replicate nodes. vector_length(), vector_length_in_bytes() and vector_length_encoding() merged ahead to pass the build.

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/286