### PR TITLE
[RISCV] Backport RVV and support RVV-0.7.1

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -159,6 +159,12 @@ ifeq ($(call check-jvm-feature, compiler2), true)
       )))
   endif
 
+  ifeq ($(HOTSPOT_TARGET_CPU_ARCH), riscv)
+    AD_SRC_FILES += $(call uniq, $(wildcard $(foreach d, $(AD_SRC_ROOTS), \
+        $d/cpu/$(HOTSPOT_TARGET_CPU_ARCH)/$(HOTSPOT_TARGET_CPU_ARCH)_v.ad \
+    )))
+  endif
+
   SINGLE_AD_SRCFILE := $(ADLC_SUPPORT_DIR)/all-ad-src.ad
 
   INSERT_FILENAME_AWK_SCRIPT := \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1254,6 +1254,15 @@ enum VTA {
   ta, // agnostic
 };
 
+static Assembler::SEW elembytes_to_sew(int ebytes) {
+  assert(ebytes > 0 && ebytes <= 8, "unsupported element size");
+  return (Assembler::SEW) exact_log2(ebytes);
+}
+
+static Assembler::SEW elemtype_to_sew(BasicType etype) {
+  return Assembler::elembytes_to_sew(type2aelembytes(etype));
+}
+
 #define patch_vtype(hsb, lsb, vlmul, vsew, vta, vma, vill)   \
     if (vill == 1) {                                         \
       guarantee((vlmul | vsew | vsew | vta | vma == 0),      \
@@ -1270,12 +1279,27 @@ enum VTA {
   void NAME(Register Rd, Register Rs1, SEW sew, LMUL lmul = m1,           \
             VMA vma = mu, VTA vta = tu, bool vill = false) {              \
     unsigned insn = 0;                                                    \
-    patch((address)&insn, 6, 0, op);                                      \
-    patch((address)&insn, 14, 12, funct3);                                \
-    patch_vtype(30, 20, lmul, sew, vta, vma, vill);                       \
-    patch((address)&insn, 31, 0);                                         \
-    patch_reg((address)&insn, 7, Rd);                                     \
-    patch_reg((address)&insn, 15, Rs1);                                   \
+    if (UseRVV071) {                                                      \
+      patch((address)&insn, 6, 0, op);                                    \
+      patch_reg((address)&insn, 7, Rd);                                   \
+      patch((address)&insn, 14, 12, funct3);                              \
+      patch_reg((address)&insn, 15, Rs1);                                 \
+      assert_cond(sew >= e8 && sew <= e128);                              \
+      assert_cond(lmul >= m1 && lmul <= m8);                              \
+      assert_cond(vma == mu && vta == tu && vill == false);               \
+      int ediv = 0;  /* ignore ediv */                                    \
+      patch((address)&insn, 21, 20, lmul);                                \
+      patch((address)&insn, 24, 22, sew);                                 \
+      patch((address)&insn, 26, 25, ediv);                                \
+      patch((address)&insn, 31, 27, 0);                                   \
+    } else {                                                             \
+      patch((address)&insn, 6, 0, op);                                    \
+      patch((address)&insn, 14, 12, funct3);                              \
+      patch_vtype(30, 20, lmul, sew, vta, vma, vill);                     \
+      patch((address)&insn, 31, 0);                                       \
+      patch_reg((address)&insn, 7, Rd);                                   \
+      patch_reg((address)&insn, 15, Rs1);                                 \
+    }                                                                     \
     emit(insn);                                                           \
   }
 
@@ -1286,6 +1310,7 @@ enum VTA {
 #define INSN(NAME, op, funct3)                                            \
   void NAME(Register Rd, uint32_t imm, SEW sew, LMUL lmul = m1,           \
             VMA vma = mu, VTA vta = tu, bool vill = false) {              \
+    assert_cond(!UseRVV071);                                              \
     unsigned insn = 0;                                                    \
     guarantee(is_unsigned_imm_in_range(imm, 5, 0), "imm is invalid");     \
     patch((address)&insn, 6, 0, op);                                      \
@@ -1312,6 +1337,7 @@ enum VectorMask {
 #define INSN(NAME, op, funct3, funct5)                                   \
   void NAME(VectorRegister vSrc, Register rBase, VectorRegister vOffset, \
             bool src_as_dst, VectorMask vm = unmasked) {                 \
+    assert_cond(!UseRVV071);                                             \
     unsigned insn = 0;                                                   \
     patch((address)&insn, 6, 0, op);                                     \
     patch((address)&insn, 14, 12, funct3);                               \
@@ -1373,8 +1399,19 @@ enum VectorMask {
 
   // Vector Mask
   INSN(vpopc_m,  0b1010111, 0b010, 0b10000, 0b010000);
-  INSN(vfirst_m, 0b1010111, 0b010, 0b10001, 0b010000);
+  INSN(_vfirst_m, 0b1010111, 0b010, 0b10001, 0b010000);
+
+  // vector 0.7.1
+  INSN(_vmfirst_m, 0b1010111, 0b010, 0b00000, 0b010101);
 #undef INSN
+
+  void vfirst_m(Register Rd, VectorRegister Vs2, VectorMask vm = unmasked) {
+    if (UseRVV071) {
+      _vmfirst_m(Rd, Vs2, vm);
+    } else {
+      _vfirst_m(Rd, Vs2, vm);
+    }
+  }
 
 #define INSN(NAME, op, funct3, Vs1, funct6)                                    \
   void NAME(VectorRegister Vd, VectorRegister Vs2, VectorMask vm = unmasked) { \
@@ -1390,10 +1427,13 @@ enum VectorMask {
   INSN(vsext_vf8, 0b1010111, 0b010, 0b00011, 0b010010);
 
   // Vector Mask
-  INSN(vmsbf_m,   0b1010111, 0b010, 0b00001, 0b010100);
+  INSN(_vmsbf_m,   0b1010111, 0b010, 0b00001, 0b010100);
   INSN(vmsif_m,   0b1010111, 0b010, 0b00011, 0b010100);
   INSN(vmsof_m,   0b1010111, 0b010, 0b00010, 0b010100);
   INSN(viota_m,   0b1010111, 0b010, 0b10000, 0b010100);
+
+  // Vector Mask for rvv0.7.1
+  INSN(_vmsbf_m_071,   0b1010111, 0b010, 0b00001, 0b010110);
 
   // Vector Single-Width Floating-Point/Integer Type-Convert Instructions
   INSN(vfcvt_xu_f_v, 0b1010111, 0b001, 0b00000, 0b010010);
@@ -1427,6 +1467,14 @@ enum VectorMask {
   INSN(vfclass_v, 0b1010111, 0b001, 0b10000, 0b010011);
 
 #undef INSN
+
+  void vmsbf_m(VectorRegister Vd, VectorRegister Vs2, VectorMask vm = unmasked) {
+    if (UseRVV071) {
+      _vmsbf_m_071(Vd, Vs2, vm);
+    } else {
+      _vmsbf_m(Vd, Vs2, vm);
+    }
+  }
 
 // r2rd
 #define INSN(NAME, op, funct3, simm5, vm, funct6)         \
@@ -2124,6 +2172,19 @@ enum Nf {
   INSN(vse16_v, 0b0100111, 0b101, 0b00000, 0b00, 0b0);
   INSN(vse32_v, 0b0100111, 0b110, 0b00000, 0b00, 0b0);
   INSN(vse64_v, 0b0100111, 0b111, 0b00000, 0b00, 0b0);
+
+#undef INSN
+
+#define INSN(NAME, op, width, umop, mop, mew)                                               \
+  void NAME(VectorRegister Vd_or_Vs3, Register Rs1, VectorMask vm = unmasked, Nf nf = g1) { \
+    patch_VLdSt(op, Vd_or_Vs3, width, Rs1, umop, vm, mop, mew, nf);                         \
+  }
+
+  // Vector Unit-Stride Instructions for RVV-0.7.1
+  // unsigned
+  INSN(vlbu_v,   0b0000111, 0b000, 0b00000, 0b00, 0b1);
+  INSN(vlhu_v,   0b0000111, 0b101, 0b00000, 0b00, 0b1);
+  INSN(vlwu_v,   0b0000111, 0b110, 0b00000, 0b00, 0b1);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -748,7 +748,6 @@ void LIR_Assembler::stack2reg(LIR_Opr src, LIR_Opr dest, BasicType type) {
 }
 
 void LIR_Assembler::klass2reg_with_patching(Register reg, CodeEmitInfo* info) {
-  // TODO: wind: ??? why deopt???
   deoptimize_trap(info);
 }
 

--- a/src/hotspot/cpu/riscv/c1_globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_globals_riscv.hpp
@@ -33,8 +33,6 @@
 // Sets the default values for platform dependent flags used by the client compiler.
 // (see c1_globals.hpp)
 
-// TODO: wind: will this configs affect performance?
-
 #ifndef TIERED
 define_pd_global(bool, BackgroundCompilation,        true );
 define_pd_global(bool, UseTLAB,                      true );

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -109,6 +109,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Extend fence.i to fence.i + fence.")                         \
   product(bool, AvoidUnalignedAccesses, true,                           \
           "Avoid generating unaligned memory accesses")                 \
+  product(bool, UseRVV, false, "Use RVV instructions")                  \
+  product(bool, UseRVV071, false, "Use RVV 0.7.1 instructions")         \
   product(bool, UseCSky, false, "Use CSky specific instructions")       \
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1125,6 +1125,18 @@ int MacroAssembler::pop_fp(unsigned int bitset, Register stack) {
   return count;
 }
 
+void MacroAssembler::vmnot_m(VectorRegister vd, VectorRegister vs) {
+  vmnand_mm(vd, vs, vs);
+}
+
+void MacroAssembler::vncvt_x_x_w(VectorRegister vd, VectorRegister vs, VectorMask vm) {
+  vnsrl_wx(vd, vs, x0, vm);
+}
+
+void MacroAssembler::vfneg_v(VectorRegister vd, VectorRegister vs) {
+  vfsgnjn_vv(vd, vs, vs);
+}
+
 // CSky specific ldd/lwd/lwud/swd/sdd to merge 2 load or 2 store instructions
 // Checks whether current and previous load/store can be merged.
 // Returns true if it can be merged, else false.
@@ -4223,6 +4235,17 @@ void MacroAssembler::zero_memory(Register addr, Register len, Register tmp1) {
   bnez(len, loop);
 }
 
+// shift left by shamt and add
+// Rd = (Rs1 << shamt) + Rs2
+void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt) {
+  if (shamt != 0) {
+    slli(tmp, Rs1, shamt);
+    add(Rd, Rs2, tmp);
+  } else {
+    add(Rd, Rs1, Rs2);
+  }
+}
+
 void MacroAssembler::zero_ext(Register dst, Register src, int clear_bits) {
   slli(dst, src, clear_bits);
   srli(dst, dst, clear_bits);
@@ -4832,4 +4855,288 @@ void MacroAssembler::minmax_FD(FloatRegister dst, FloatRegister src1, FloatRegis
 
   bind(Done);
 }
+
+void MacroAssembler::element_compare(Register a1, Register a2, Register result, Register cnt, Register tmp1, Register tmp2,
+                                      VectorRegister vr1, VectorRegister vr2, VectorRegister vrs, bool islatin, Label &DONE) {
+  Label loop;
+  Assembler::SEW sew = islatin ? Assembler::e8 : Assembler::e16;
+
+  bind(loop);
+  vsetvli(tmp1, cnt, sew, Assembler::m2);
+  vlex_v(vr1, a1, sew);
+  vlex_v(vr2, a2, sew);
+  vmsne_vv(vrs, vr1, vr2);  // vrs, vr1 and vr2 could not be the same under rvv0.7.1
+  vfirst_m(tmp2, vrs);
+  bgez(tmp2, DONE);
+  sub(cnt, cnt, tmp1);
+  if (!islatin) {
+    slli(tmp1, tmp1, 1); // get byte counts
+  }
+  add(a1, a1, tmp1);
+  add(a2, a2, tmp1);
+  bnez(cnt, loop);
+
+  mv(result, true);
+}
+
+void MacroAssembler::string_equals_v(Register a1, Register a2, Register result, Register cnt, int elem_size) {
+  Label DONE;
+  Register tmp1 = t0;
+  Register tmp2 = t1;
+
+  BLOCK_COMMENT("string_equals_v {");
+
+  mv(result, false);
+
+  if (elem_size == 2) {
+    srli(cnt, cnt, 1);
+  }
+
+  element_compare(a1, a2, result, cnt, tmp1, tmp2, v0, v2, v4, elem_size == 1, DONE);
+
+  bind(DONE);
+  BLOCK_COMMENT("} string_equals_v");
+}
+
+// used by C2 ClearArray patterns.
+// base: Address of a buffer to be zeroed
+// cnt: Count in HeapWords
+//
+// base, cnt, v0, v1 and t0 are clobbered.
+void MacroAssembler::clear_array_v(Register base, Register cnt) {
+  Label loop;
+
+  // making zero words
+  vsetvli(t0, cnt, Assembler::e64, Assembler::m4);
+  vxor_vv(v0, v0, v0);
+
+  bind(loop);
+  vsetvli(t0, cnt, Assembler::e64, Assembler::m4);
+  vse64_v(v0, base);
+  sub(cnt, cnt, t0);
+  shadd(base, t0, base, t0, 3);
+  bnez(cnt, loop);
+}
+
+void MacroAssembler::arrays_equals_v(Register a1, Register a2, Register result,
+                                      Register cnt1, int elem_size) {
+  Label DONE;
+  Register tmp1 = t0;
+  Register tmp2 = t1;
+  Register cnt2 = tmp2;
+  int length_offset = arrayOopDesc::length_offset_in_bytes();
+  int base_offset = arrayOopDesc::base_offset_in_bytes(elem_size == 2 ? T_CHAR : T_BYTE);
+
+  BLOCK_COMMENT("arrays_equals_v {");
+
+  // if (a1 == a2), return true
+  mv(result, true);
+  beq(a1, a2, DONE);
+
+  mv(result, false);
+  // if a1 == null or a2 == null, return false
+  beqz(a1, DONE);
+  beqz(a2, DONE);
+  // if (a1.length != a2.length), return false
+  lwu(cnt1, Address(a1, length_offset));
+  lwu(cnt2, Address(a2, length_offset));
+  bne(cnt1, cnt2, DONE);
+
+  la(a1, Address(a1, base_offset));
+  la(a2, Address(a2, base_offset));
+
+  element_compare(a1, a2, result, cnt1, tmp1, tmp2, v0, v2, v4, elem_size == 1, DONE);
+
+  bind(DONE);
+
+  BLOCK_COMMENT("} arrays_equals_v");
+}
+
+void MacroAssembler::string_compare_v(Register str1, Register str2, Register cnt1, Register cnt2,
+                                       Register result, Register tmp1, Register tmp2, int encForm) {
+  Label DIFFERENCE, DONE, L, loop;
+  bool encLL = encForm == StrIntrinsicNode::LL;
+  bool encLU = encForm == StrIntrinsicNode::LU;
+  bool encUL = encForm == StrIntrinsicNode::UL;
+
+  bool str1_isL = encLL || encLU;
+  bool str2_isL = encLL || encUL;
+
+  int minCharsInWord = encLL ? wordSize : wordSize / 2;
+
+  BLOCK_COMMENT("string_compare {");
+
+  // for Latin strings, 1 byte for 1 character
+  // for UTF16 strings, 2 bytes for 1 character
+  if (!str1_isL)
+    sraiw(cnt1, cnt1, 1);
+  if (!str2_isL)
+    sraiw(cnt2, cnt2, 1);
+
+  // if str1 == str2, return the difference
+  // save the minimum of the string lengths in cnt2.
+  sub(result, cnt1, cnt2);
+  bgt(cnt1, cnt2, L);
+  mv(cnt2, cnt1);
+  bind(L);
+
+  if (str1_isL == str2_isL) { // LL or UU
+    element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v2, v4, v0, encLL, DIFFERENCE);
+    j(DONE);
+  } else { // LU or UL
+    Register strL = encLU ? str1 : str2;
+    Register strU = encLU ? str2 : str1;
+    VectorRegister vstr1 = encLU ? v4 : v0;
+    VectorRegister vstr2 = encLU ? v0 : v4;
+
+    bind(loop);
+    vsetvli(tmp1, cnt2, Assembler::e8, Assembler::m2);
+    vle8_v(vstr1, strL);
+    if (UseRVV071) {
+      vwaddu_vx(vstr2, vstr1, x0);
+      vsetvli(tmp1, cnt2, Assembler::e16, Assembler::m4);
+    } else {
+      vsetvli(tmp1, cnt2, Assembler::e16, Assembler::m4);
+      vzext_vf2(vstr2, vstr1);
+    }
+    vle16_v(vstr1, strU);
+    vmsne_vv(v8, vstr2, vstr1);
+    vfirst_m(tmp2, v8);
+    bgez(tmp2, DIFFERENCE);
+    sub(cnt2, cnt2, tmp1);
+    add(strL, strL, tmp1);
+    shadd(strU, tmp1, strU, tmp1, 1);
+    bnez(cnt2, loop);
+    j(DONE);
+  }
+  bind(DIFFERENCE);
+  slli(tmp1, tmp2, 1);
+  add(str1, str1, str1_isL ? tmp2 : tmp1);
+  add(str2, str2, str2_isL ? tmp2 : tmp1);
+  str1_isL ? lbu(tmp1, Address(str1, 0)) : lhu(tmp1, Address(str1, 0));
+  str2_isL ? lbu(tmp2, Address(str2, 0)) : lhu(tmp2, Address(str2, 0));
+  sub(result, tmp1, tmp2);
+
+  bind(DONE);
+}
+
+void MacroAssembler::byte_array_inflate_v(Register src, Register dst, Register len, Register tmp) {
+  Label loop;
+  assert_different_registers(src, dst, len, tmp, t0);
+
+  BLOCK_COMMENT("byte_array_inflate_v {");
+  bind(loop);
+  vsetvli(tmp, len, Assembler::e8, Assembler::m2);
+  if (UseRVV071) {
+    vle8_v(v0, src);
+    vwaddu_vx(v4, v0, x0);
+    vsetvli(t0, len, Assembler::e16, Assembler::m4);
+    vse16_v(v4, dst);
+  } else {
+    vle8_v(v2, src);
+    vsetvli(t0, len, Assembler::e16, Assembler::m4);
+    vzext_vf2(v0, v2);
+    vse16_v(v0, dst);
+  }
+  sub(len, len, tmp);
+  add(src, src, tmp);
+  shadd(dst, tmp, dst, tmp, 1);
+  bnez(len, loop);
+  BLOCK_COMMENT("} byte_array_inflate_v");
+}
+
+// Compress char[] array to byte[].
+// result: the array length if every element in array can be encoded; 0, otherwise.
+void MacroAssembler::char_array_compress_v(Register src, Register dst, Register len, Register result, Register tmp) {
+  Label done;
+  encode_iso_array_v(src, dst, len, result, tmp);
+  beqz(len, done);
+  mv(result, zr);
+  bind(done);
+}
+
+// result: the number of elements had been encoded.
+void MacroAssembler::encode_iso_array_v(Register src, Register dst, Register len, Register result, Register tmp) {
+  Label loop, DIFFERENCE, DONE;
+
+  BLOCK_COMMENT("encode_iso_array_v {");
+  mv(result, 0);
+
+  bind(loop);
+  mv(tmp, 0xff);
+  vsetvli(t0, len, Assembler::e16, Assembler::m2);
+  vle16_v(v2, src);
+  // if element > 0xff, stop
+  vmsgtu_vx(v1, v2, tmp);
+  vfirst_m(tmp, v1);
+  vmsbf_m(v0, v1);
+  // compress char to byte
+  vsetvli(t0, len, Assembler::e8);
+  vncvt_x_x_w(v1, v2, Assembler::v0_t);
+  vse8_v(v1, dst, Assembler::v0_t);
+
+  bgez(tmp, DIFFERENCE);
+  add(result, result, t0);
+  add(dst, dst, t0);
+  sub(len, len, t0);
+  shadd(src, t0, src, t0, 1);
+  bnez(len, loop);
+  j(DONE);
+
+  bind(DIFFERENCE);
+  add(result, result, tmp);
+
+  bind(DONE);
+  BLOCK_COMMENT("} encode_iso_array_v");
+}
+
+// Set dst to NaN if any NaN input.
+void MacroAssembler::minmax_FD_v(VectorRegister dst, VectorRegister src1, VectorRegister src2,
+                                  bool is_double, bool is_min) {
+  assert_different_registers(dst, src1, src2);
+
+  ebreak();
+
+  vsetvli(t0, x0, is_double ? Assembler::e64 : Assembler::e32);
+
+  is_min ? vfmin_vv(dst, src1, src2)
+         : vfmax_vv(dst, src1, src2);
+
+  vmfne_vv(v0,  src1, src1);
+  vfadd_vv(dst, src1, src1, Assembler::v0_t);
+  vmfne_vv(v0,  src2, src2);
+  vfadd_vv(dst, src2, src2, Assembler::v0_t);
+}
+
+// Set dst to NaN if any NaN input.
+void MacroAssembler::reduce_minmax_FD_v(FloatRegister dst,
+                                         FloatRegister src1, VectorRegister src2,
+                                         VectorRegister tmp1, VectorRegister tmp2,
+                                         bool is_double, bool is_min) {
+  assert_different_registers(src2, tmp1, tmp2);
+
+  ebreak();
+
+  Label L_done, L_NaN;
+  vsetvli(t0, x0, is_double ? Assembler::e64 : Assembler::e32);
+  vfmv_s_f(tmp2, src1);
+
+  is_min ? vfredmin_vs(tmp1, src2, tmp2)
+         : vfredmax_vs(tmp1, src2, tmp2);
+
+  fsflags(zr);
+  // Checking NaNs
+  vmflt_vf(tmp2, src2, src1);
+  frflags(t0);
+  bnez(t0, L_NaN);
+  j(L_done);
+
+  bind(L_NaN);
+  vfmv_s_f(tmp2, src1);
+  vfredsum_vs(tmp1, src2, tmp2);
+
+  bind(L_done);
+  vfmv_f_s(dst, tmp1);
+}
+
 #endif // COMPILER2

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -766,6 +766,9 @@ class MacroAssembler: public Assembler {
   void fill_words(Register base, Register cnt, Register value);
   void zero_memory(Register addr, Register len, Register tmp1);
 
+  // shift left by shamt and add
+  void shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
+
 #ifdef COMPILER2
   // refer to conditional_branches and float_conditional_branches
   static const int bool_test_bits = 3;
@@ -798,6 +801,43 @@ class MacroAssembler: public Assembler {
   void fcvt_l_s_safe(Register dst, FloatRegister src, Register temp = t0);
   void fcvt_w_d_safe(Register dst, FloatRegister src, Register temp = t0);
   void fcvt_l_d_safe(Register dst, FloatRegister src, Register temp = t0);
+
+  // vector load/store unit-stride instructions
+  void vlex_v(VectorRegister vd, Register base, Assembler::SEW sew, VectorMask vm = unmasked) {
+    switch (sew) {
+      case Assembler::e64:
+        vle64_v(vd, base, vm);
+        break;
+      case Assembler::e32:
+        vle32_v(vd, base, vm);
+        break;
+      case Assembler::e16:
+        vle16_v(vd, base, vm);
+        break;
+      case Assembler::e8: // fall through
+      default:
+        vle8_v(vd, base, vm);
+        break;
+    }
+  }
+
+  void vsex_v(VectorRegister store_data, Register base, Assembler::SEW sew, VectorMask vm = unmasked) {
+    switch (sew) {
+      case Assembler::e64:
+        vse64_v(store_data, base, vm);
+        break;
+      case Assembler::e32:
+        vse32_v(store_data, base, vm);
+        break;
+      case Assembler::e16:
+        vse16_v(store_data, base, vm);
+        break;
+      case Assembler::e8: // fall through
+      default:
+        vse8_v(store_data, base, vm);
+        break;
+    }
+  }
 
   static const int zero_words_block_size;
 
@@ -843,6 +883,11 @@ class MacroAssembler: public Assembler {
   int push_fp(unsigned int bitset, Register stack);
   int pop_fp(unsigned int bitset, Register stack);
 
+  // vext
+  void vmnot_m(VectorRegister vd, VectorRegister vs);
+  void vncvt_x_x_w(VectorRegister vd, VectorRegister vs, VectorMask vm = unmasked);
+  void vfneg_v(VectorRegister vd, VectorRegister vs);
+
 #ifdef COMPILER2
   void string_indexof(Register str1, Register str2,
                       Register cnt1, Register cnt2,
@@ -865,6 +910,68 @@ class MacroAssembler: public Assembler {
   void minmax_FD(FloatRegister dst,
                  FloatRegister src1, FloatRegister src2,
                  bool is_double, bool is_min);
+
+  void spill(VectorRegister v, int offset) {
+    add(t0, sp, offset);
+    vs1r_v(v, t0);
+  }
+
+  void unspill(VectorRegister v, int offset) {
+    add(t0, sp, offset);
+    vl1r_v(v, t0);
+  }
+
+  void spill_copy_vector_stack_to_stack(int src_offset, int dst_offset, int vec_reg_size_in_bytes) {
+    assert(vec_reg_size_in_bytes % 16 == 0, "unexpected vector reg size");
+    unspill(v0, src_offset);
+    spill(v0, dst_offset);
+  }
+
+private:
+  void element_compare(Register r1, Register r2,
+                       Register result, Register cnt,
+                       Register tmp1, Register tmp2,
+                       VectorRegister vr1, VectorRegister vr2,
+                       VectorRegister vrs,
+                       bool is_latin, Label& DONE);
+public:
+  // intrinsic methods implemented by rvv instructions
+  void string_equals_v(Register r1, Register r2,
+                       Register result, Register cnt1,
+                       int elem_size);
+
+  void arrays_equals_v(Register r1, Register r2,
+                       Register result, Register cnt1,
+                       int elem_size);
+
+  void string_compare_v(Register str1, Register str2,
+                        Register cnt1, Register cnt2,
+                        Register result,
+                        Register tmp1, Register tmp2,
+                        int encForm);
+
+  void clear_array_v(Register base, Register cnt);
+
+  void byte_array_inflate_v(Register src, Register dst,
+                            Register len, Register tmp);
+
+  void char_array_compress_v(Register src, Register dst,
+                             Register len, Register result,
+                             Register tmp);
+
+  void encode_iso_array_v(Register src, Register dst,
+                          Register len, Register result,
+                          Register tmp);
+
+  void minmax_FD_v(VectorRegister dst,
+                   VectorRegister src1, VectorRegister src2,
+                   bool is_double, bool is_min);
+
+  void reduce_minmax_FD_v(FloatRegister dst,
+                          FloatRegister src1, VectorRegister src2,
+                          VectorRegister tmp1, VectorRegister tmp2,
+                          bool is_double, bool is_min);
+
 #endif // COMPILER2
 
 private:

--- a/src/hotspot/cpu/riscv/register_riscv.hpp
+++ b/src/hotspot/cpu/riscv/register_riscv.hpp
@@ -268,8 +268,8 @@ class ConcreteRegisterImpl : public AbstractRegisterImpl {
   // it's optoregs.
 
     number_of_registers = (RegisterImpl::max_slots_per_register * RegisterImpl::number_of_registers +
-                           FloatRegisterImpl::max_slots_per_register * FloatRegisterImpl::number_of_registers)
-         // TODO: we fixed the register number but remained the vregs' definitions
+                           FloatRegisterImpl::max_slots_per_register * FloatRegisterImpl::number_of_registers +
+                           VectorRegisterImpl::max_slots_per_register * VectorRegisterImpl::number_of_registers)
   };
 
   // added to make it compile

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -226,6 +226,177 @@ reg_def F30_H ( SOC, SOC, Op_RegF,  30, f30->as_VMReg()->next() );
 reg_def F31   ( SOC, SOC, Op_RegF,  31, f31->as_VMReg()         );
 reg_def F31_H ( SOC, SOC, Op_RegF,  31, f31->as_VMReg()->next() );
 
+// ----------------------------
+// Vector Registers
+// ----------------------------
+
+// For RVV vector registers, we simply extend vector register size to 4
+// 'logical' slots. This is nominally 128 bits but it actually covers
+// all possible 'physical' RVV vector register lengths from 128 ~ 1024
+// bits. The 'physical' RVV vector register length is detected during
+// startup, so the register allocator is able to identify the correct
+// number of bytes needed for an RVV spill/unspill.
+
+reg_def V0    ( SOC, SOC, Op_VecX, 0,  v0->as_VMReg()           );
+reg_def V0_H  ( SOC, SOC, Op_VecX, 0,  v0->as_VMReg()->next()   );
+reg_def V0_J  ( SOC, SOC, Op_VecX, 0,  v0->as_VMReg()->next(2)  );
+reg_def V0_K  ( SOC, SOC, Op_VecX, 0,  v0->as_VMReg()->next(3)  );
+
+reg_def V1    ( SOC, SOC, Op_VecX, 1,  v1->as_VMReg() 	        );
+reg_def V1_H  ( SOC, SOC, Op_VecX, 1,  v1->as_VMReg()->next()   );
+reg_def V1_J  ( SOC, SOC, Op_VecX, 1,  v1->as_VMReg()->next(2)  );
+reg_def V1_K  ( SOC, SOC, Op_VecX, 1,  v1->as_VMReg()->next(3)  );
+
+reg_def V2    ( SOC, SOC, Op_VecX, 2,  v2->as_VMReg()           );
+reg_def V2_H  ( SOC, SOC, Op_VecX, 2,  v2->as_VMReg()->next()   );
+reg_def V2_J  ( SOC, SOC, Op_VecX, 2,  v2->as_VMReg()->next(2)  );
+reg_def V2_K  ( SOC, SOC, Op_VecX, 2,  v2->as_VMReg()->next(3)  );
+
+reg_def V3    ( SOC, SOC, Op_VecX, 3,  v3->as_VMReg()           );
+reg_def V3_H  ( SOC, SOC, Op_VecX, 3,  v3->as_VMReg()->next()   );
+reg_def V3_J  ( SOC, SOC, Op_VecX, 3,  v3->as_VMReg()->next(2)  );
+reg_def V3_K  ( SOC, SOC, Op_VecX, 3,  v3->as_VMReg()->next(3)  );
+
+reg_def V4    ( SOC, SOC, Op_VecX, 4,  v4->as_VMReg()           );
+reg_def V4_H  ( SOC, SOC, Op_VecX, 4,  v4->as_VMReg()->next()   );
+reg_def V4_J  ( SOC, SOC, Op_VecX, 4,  v4->as_VMReg()->next(2)  );
+reg_def V4_K  ( SOC, SOC, Op_VecX, 4,  v4->as_VMReg()->next(3)  );
+
+reg_def V5    ( SOC, SOC, Op_VecX, 5,  v5->as_VMReg() 	        );
+reg_def V5_H  ( SOC, SOC, Op_VecX, 5,  v5->as_VMReg()->next()   );
+reg_def V5_J  ( SOC, SOC, Op_VecX, 5,  v5->as_VMReg()->next(2)  );
+reg_def V5_K  ( SOC, SOC, Op_VecX, 5,  v5->as_VMReg()->next(3)  );
+
+reg_def V6    ( SOC, SOC, Op_VecX, 6,  v6->as_VMReg()           );
+reg_def V6_H  ( SOC, SOC, Op_VecX, 6,  v6->as_VMReg()->next()   );
+reg_def V6_J  ( SOC, SOC, Op_VecX, 6,  v6->as_VMReg()->next(2)  );
+reg_def V6_K  ( SOC, SOC, Op_VecX, 6,  v6->as_VMReg()->next(3)  );
+
+reg_def V7    ( SOC, SOC, Op_VecX, 7,  v7->as_VMReg() 	        );
+reg_def V7_H  ( SOC, SOC, Op_VecX, 7,  v7->as_VMReg()->next()   );
+reg_def V7_J  ( SOC, SOC, Op_VecX, 7,  v7->as_VMReg()->next(2)  );
+reg_def V7_K  ( SOC, SOC, Op_VecX, 7,  v7->as_VMReg()->next(3)  );
+
+reg_def V8    ( SOC, SOC, Op_VecX, 8,  v8->as_VMReg()           );
+reg_def V8_H  ( SOC, SOC, Op_VecX, 8,  v8->as_VMReg()->next()   );
+reg_def V8_J  ( SOC, SOC, Op_VecX, 8,  v8->as_VMReg()->next(2)  );
+reg_def V8_K  ( SOC, SOC, Op_VecX, 8,  v8->as_VMReg()->next(3)  );
+
+reg_def V9    ( SOC, SOC, Op_VecX, 9,  v9->as_VMReg()           );
+reg_def V9_H  ( SOC, SOC, Op_VecX, 9,  v9->as_VMReg()->next()   );
+reg_def V9_J  ( SOC, SOC, Op_VecX, 9,  v9->as_VMReg()->next(2)  );
+reg_def V9_K  ( SOC, SOC, Op_VecX, 9,  v9->as_VMReg()->next(3)  );
+
+reg_def V10   ( SOC, SOC, Op_VecX, 10, v10->as_VMReg()          );
+reg_def V10_H ( SOC, SOC, Op_VecX, 10, v10->as_VMReg()->next()  );
+reg_def V10_J ( SOC, SOC, Op_VecX, 10, v10->as_VMReg()->next(2) );
+reg_def V10_K ( SOC, SOC, Op_VecX, 10, v10->as_VMReg()->next(3) );
+
+reg_def V11   ( SOC, SOC, Op_VecX, 11, v11->as_VMReg()          );
+reg_def V11_H ( SOC, SOC, Op_VecX, 11, v11->as_VMReg()->next()  );
+reg_def V11_J ( SOC, SOC, Op_VecX, 11, v11->as_VMReg()->next(2) );
+reg_def V11_K ( SOC, SOC, Op_VecX, 11, v11->as_VMReg()->next(3) );
+
+reg_def V12   ( SOC, SOC, Op_VecX, 12, v12->as_VMReg()          );
+reg_def V12_H ( SOC, SOC, Op_VecX, 12, v12->as_VMReg()->next()  );
+reg_def V12_J ( SOC, SOC, Op_VecX, 12, v12->as_VMReg()->next(2) );
+reg_def V12_K ( SOC, SOC, Op_VecX, 12, v12->as_VMReg()->next(3) );
+
+reg_def V13   ( SOC, SOC, Op_VecX, 13, v13->as_VMReg()          );
+reg_def V13_H ( SOC, SOC, Op_VecX, 13, v13->as_VMReg()->next()  );
+reg_def V13_J ( SOC, SOC, Op_VecX, 13, v13->as_VMReg()->next(2) );
+reg_def V13_K ( SOC, SOC, Op_VecX, 13, v13->as_VMReg()->next(3) );
+
+reg_def V14   ( SOC, SOC, Op_VecX, 14, v14->as_VMReg()          );
+reg_def V14_H ( SOC, SOC, Op_VecX, 14, v14->as_VMReg()->next()  );
+reg_def V14_J ( SOC, SOC, Op_VecX, 14, v14->as_VMReg()->next(2) );
+reg_def V14_K ( SOC, SOC, Op_VecX, 14, v14->as_VMReg()->next(3) );
+
+reg_def V15   ( SOC, SOC, Op_VecX, 15, v15->as_VMReg()          );
+reg_def V15_H ( SOC, SOC, Op_VecX, 15, v15->as_VMReg()->next()  );
+reg_def V15_J ( SOC, SOC, Op_VecX, 15, v15->as_VMReg()->next(2) );
+reg_def V15_K ( SOC, SOC, Op_VecX, 15, v15->as_VMReg()->next(3) );
+
+reg_def V16   ( SOC, SOC, Op_VecX, 16, v16->as_VMReg()          );
+reg_def V16_H ( SOC, SOC, Op_VecX, 16, v16->as_VMReg()->next()  );
+reg_def V16_J ( SOC, SOC, Op_VecX, 16, v16->as_VMReg()->next(2) );
+reg_def V16_K ( SOC, SOC, Op_VecX, 16, v16->as_VMReg()->next(3) );
+
+reg_def V17   ( SOC, SOC, Op_VecX, 17, v17->as_VMReg()          );
+reg_def V17_H ( SOC, SOC, Op_VecX, 17, v17->as_VMReg()->next()  );
+reg_def V17_J ( SOC, SOC, Op_VecX, 17, v17->as_VMReg()->next(2) );
+reg_def V17_K ( SOC, SOC, Op_VecX, 17, v17->as_VMReg()->next(3) );
+
+reg_def V18   ( SOC, SOC, Op_VecX, 18, v18->as_VMReg()          );
+reg_def V18_H ( SOC, SOC, Op_VecX, 18, v18->as_VMReg()->next()  );
+reg_def V18_J ( SOC, SOC, Op_VecX, 18, v18->as_VMReg()->next(2) );
+reg_def V18_K ( SOC, SOC, Op_VecX, 18, v18->as_VMReg()->next(3) );
+
+reg_def V19   ( SOC, SOC, Op_VecX, 19, v19->as_VMReg()          );
+reg_def V19_H ( SOC, SOC, Op_VecX, 19, v19->as_VMReg()->next()  );
+reg_def V19_J ( SOC, SOC, Op_VecX, 19, v19->as_VMReg()->next(2) );
+reg_def V19_K ( SOC, SOC, Op_VecX, 19, v19->as_VMReg()->next(3) );
+
+reg_def V20   ( SOC, SOC, Op_VecX, 20, v20->as_VMReg()          );
+reg_def V20_H ( SOC, SOC, Op_VecX, 20, v20->as_VMReg()->next()  );
+reg_def V20_J ( SOC, SOC, Op_VecX, 20, v20->as_VMReg()->next(2) );
+reg_def V20_K ( SOC, SOC, Op_VecX, 20, v20->as_VMReg()->next(3) );
+
+reg_def V21   ( SOC, SOC, Op_VecX, 21, v21->as_VMReg()          );
+reg_def V21_H ( SOC, SOC, Op_VecX, 21, v21->as_VMReg()->next()  );
+reg_def V21_J ( SOC, SOC, Op_VecX, 21, v21->as_VMReg()->next(2) );
+reg_def V21_K ( SOC, SOC, Op_VecX, 21, v21->as_VMReg()->next(3) );
+
+reg_def V22   ( SOC, SOC, Op_VecX, 22, v22->as_VMReg()          );
+reg_def V22_H ( SOC, SOC, Op_VecX, 22, v22->as_VMReg()->next()  );
+reg_def V22_J ( SOC, SOC, Op_VecX, 22, v22->as_VMReg()->next(2) );
+reg_def V22_K ( SOC, SOC, Op_VecX, 22, v22->as_VMReg()->next(3) );
+
+reg_def V23   ( SOC, SOC, Op_VecX, 23, v23->as_VMReg()          );
+reg_def V23_H ( SOC, SOC, Op_VecX, 23, v23->as_VMReg()->next()  );
+reg_def V23_J ( SOC, SOC, Op_VecX, 23, v23->as_VMReg()->next(2) );
+reg_def V23_K ( SOC, SOC, Op_VecX, 23, v23->as_VMReg()->next(3) );
+
+reg_def V24   ( SOC, SOC, Op_VecX, 24, v24->as_VMReg()          );
+reg_def V24_H ( SOC, SOC, Op_VecX, 24, v24->as_VMReg()->next()  );
+reg_def V24_J ( SOC, SOC, Op_VecX, 24, v24->as_VMReg()->next(2) );
+reg_def V24_K ( SOC, SOC, Op_VecX, 24, v24->as_VMReg()->next(3) );
+
+reg_def V25   ( SOC, SOC, Op_VecX, 25, v25->as_VMReg()          );
+reg_def V25_H ( SOC, SOC, Op_VecX, 25, v25->as_VMReg()->next()  );
+reg_def V25_J ( SOC, SOC, Op_VecX, 25, v25->as_VMReg()->next(2) );
+reg_def V25_K ( SOC, SOC, Op_VecX, 25, v25->as_VMReg()->next(3) );
+
+reg_def V26   ( SOC, SOC, Op_VecX, 26, v26->as_VMReg()          );
+reg_def V26_H ( SOC, SOC, Op_VecX, 26, v26->as_VMReg()->next()  );
+reg_def V26_J ( SOC, SOC, Op_VecX, 26, v26->as_VMReg()->next(2) );
+reg_def V26_K ( SOC, SOC, Op_VecX, 26, v26->as_VMReg()->next(3) );
+
+reg_def V27   ( SOC, SOC, Op_VecX, 27, v27->as_VMReg()          );
+reg_def V27_H ( SOC, SOC, Op_VecX, 27, v27->as_VMReg()->next()  );
+reg_def V27_J ( SOC, SOC, Op_VecX, 27, v27->as_VMReg()->next(2) );
+reg_def V27_K ( SOC, SOC, Op_VecX, 27, v27->as_VMReg()->next(3) );
+
+reg_def V28   ( SOC, SOC, Op_VecX, 28, v28->as_VMReg()          );
+reg_def V28_H ( SOC, SOC, Op_VecX, 28, v28->as_VMReg()->next()  );
+reg_def V28_J ( SOC, SOC, Op_VecX, 28, v28->as_VMReg()->next(2) );
+reg_def V28_K ( SOC, SOC, Op_VecX, 28, v28->as_VMReg()->next(3) );
+
+reg_def V29   ( SOC, SOC, Op_VecX, 29, v29->as_VMReg()          );
+reg_def V29_H ( SOC, SOC, Op_VecX, 29, v29->as_VMReg()->next()  );
+reg_def V29_J ( SOC, SOC, Op_VecX, 29, v29->as_VMReg()->next(2) );
+reg_def V29_K ( SOC, SOC, Op_VecX, 29, v29->as_VMReg()->next(3) );
+
+reg_def V30   ( SOC, SOC, Op_VecX, 30, v30->as_VMReg()          );
+reg_def V30_H ( SOC, SOC, Op_VecX, 30, v30->as_VMReg()->next()  );
+reg_def V30_J ( SOC, SOC, Op_VecX, 30, v30->as_VMReg()->next(2) );
+reg_def V30_K ( SOC, SOC, Op_VecX, 30, v30->as_VMReg()->next(3) );
+
+reg_def V31   ( SOC, SOC, Op_VecX, 31, v31->as_VMReg()          );
+reg_def V31_H ( SOC, SOC, Op_VecX, 31, v31->as_VMReg()->next()  );
+reg_def V31_J ( SOC, SOC, Op_VecX, 31, v31->as_VMReg()->next(2) );
+reg_def V31_K ( SOC, SOC, Op_VecX, 31, v31->as_VMReg()->next(3) );
+
 // Double Registers
 
 // The rules of ADL require that double registers be defined in pairs.
@@ -342,7 +513,42 @@ alloc_class chunk1(
     F27, F27_H,
 );
 
-alloc_class chunk2(RFLAGS);
+alloc_class chunk2(
+    V0, V0_H, V0_J, V0_K,
+    V1, V1_H, V1_J, V1_K,
+    V2, V2_H, V2_J, V2_K,
+    V3, V3_H, V3_J, V3_K,
+    V4, V4_H, V4_J, V4_K,
+    V5, V5_H, V5_J, V5_K,
+    V6, V6_H, V6_J, V6_K,
+    V7, V7_H, V7_J, V7_K,
+    V8, V8_H, V8_J, V8_K,
+    V9, V9_H, V9_J, V9_K,
+    V10, V10_H, V10_J, V10_K,
+    V11, V11_H, V11_J, V11_K,
+    V12, V12_H, V12_J, V12_K,
+    V13, V13_H, V13_J, V13_K,
+    V14, V14_H, V14_J, V14_K,
+    V15, V15_H, V15_J, V15_K,
+    V16, V16_H, V16_J, V16_K,
+    V17, V17_H, V17_J, V17_K,
+    V18, V18_H, V18_J, V18_K,
+    V19, V19_H, V19_J, V19_K,
+    V20, V20_H, V20_J, V20_K,
+    V21, V21_H, V21_J, V21_K,
+    V22, V22_H, V22_J, V22_K,
+    V23, V23_H, V23_J, V23_K,
+    V24, V24_H, V24_J, V24_K,
+    V25, V25_H, V25_J, V25_K,
+    V26, V26_H, V26_J, V26_K,
+    V27, V27_H, V27_J, V27_K,
+    V28, V28_H, V28_J, V28_K,
+    V29, V29_H, V29_J, V29_K,
+    V30, V30_H, V30_J, V30_K,
+    V31, V31_H, V31_J, V31_K,
+);
+
+alloc_class chunk3(RFLAGS);
 
 //----------Architecture Description Register Classes--------------------------
 // Several register classes are automatically defined based upon information in
@@ -646,6 +852,37 @@ reg_class vectord_reg(
 
 // Class for all 128bit vector registers
 reg_class vectorx_reg(
+    V1, V1_H, V1_J, V1_K,
+    V2, V2_H, V2_J, V2_K,
+    V3, V3_H, V3_J, V3_K,
+    V4, V4_H, V4_J, V4_K,
+    V5, V5_H, V5_J, V5_K,
+    V6, V6_H, V6_J, V6_K,
+    V7, V7_H, V7_J, V7_K,
+    V8, V8_H, V8_J, V8_K,
+    V9, V9_H, V9_J, V9_K,
+    V10, V10_H, V10_J, V10_K,
+    V11, V11_H, V11_J, V11_K,
+    V12, V12_H, V12_J, V12_K,
+    V13, V13_H, V13_J, V13_K,
+    V14, V14_H, V14_J, V14_K,
+    V15, V15_H, V15_J, V15_K,
+    V16, V16_H, V16_J, V16_K,
+    V17, V17_H, V17_J, V17_K,
+    V18, V18_H, V18_J, V18_K,
+    V19, V19_H, V19_J, V19_K,
+    V20, V20_H, V20_J, V20_K,
+    V21, V21_H, V21_J, V21_K,
+    V22, V22_H, V22_J, V22_K,
+    V23, V23_H, V23_J, V23_K,
+    V24, V24_H, V24_J, V24_K,
+    V25, V25_H, V25_J, V25_K,
+    V26, V26_H, V26_J, V26_K,
+    V27, V27_H, V27_J, V27_K,
+    V28, V28_H, V28_J, V28_K,
+    V29, V29_H, V29_J, V29_K,
+    V30, V30_H, V30_J, V30_K,
+    V31, V31_H, V31_J, V31_K
 );
 
 // Class for 64 bit register f0
@@ -666,6 +903,31 @@ reg_class f2_reg(
 // Class for 64 bit register f3
 reg_class f3_reg(
     F3, F3_H
+);
+
+// class for vector register v1
+reg_class v1_reg(
+    V1, V1_H, V1_J, V1_K
+);
+
+// class for vector register v2
+reg_class v2_reg(
+    V2, V2_H, V2_J, V2_K
+);
+
+// class for vector register v3
+reg_class v3_reg(
+    V3, V3_H, V3_J, V3_K
+);
+
+// class for vector register v4
+reg_class v4_reg(
+    V4, V4_H, V4_J, V4_K
+);
+
+// class for vector register v5
+reg_class v5_reg(
+    V5, V5_H, V5_J, V5_K
 );
 
 // class for condition codes
@@ -1187,7 +1449,7 @@ int MachEpilogNode::safepoint_offset() const {
 
 // Figure out which register class each belongs in: rc_int, rc_float or
 // rc_stack.
-enum RC { rc_bad, rc_int, rc_float, rc_stack };
+enum RC { rc_bad, rc_int, rc_float, rc_vector, rc_stack };
 
 static enum RC rc_class(OptoReg::Name reg) {
 
@@ -1246,8 +1508,30 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
   int src_offset = ra_->reg2offset(src_lo);
   int dst_offset = ra_->reg2offset(dst_lo);
 
-  if (bottom_type() == NULL || bottom_type()->isa_vect() != NULL) {
-    ShouldNotReachHere();
+  if (bottom_type()->isa_vect() != NULL) {
+    uint ireg = ideal_reg();
+    if (ireg == Op_VecX && cbuf) {
+      MacroAssembler _masm(cbuf);
+      const int vector_reg_size_in_bytes = 16;
+      if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
+        // stack to stack
+        __ spill_copy_vector_stack_to_stack(src_offset, dst_offset,
+                                            vector_reg_size_in_bytes);
+      } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_stack) {
+        // vpr to stack
+        __ spill(as_VectorRegister(Matcher::_regEncode[src_lo]), ra_->reg2offset(dst_lo));
+      } else if (src_lo_rc == rc_stack && dst_lo_rc == rc_vector) {
+        // stack to vpr
+        __ unspill(as_VectorRegister(Matcher::_regEncode[dst_lo]), ra_->reg2offset(src_lo));
+      } else if (src_lo_rc == rc_vector && dst_lo_rc == rc_vector) {
+        // vpr to vpr
+        __ vmv1r_v(as_VectorRegister(Matcher::_regEncode[dst_lo]), as_VectorRegister(Matcher::_regEncode[src_lo]));
+      } else {
+        ShouldNotReachHere();
+      }
+    } else {
+      ShouldNotReachHere();
+    }
   } else if (cbuf != NULL) {
     MacroAssembler _masm(cbuf);
     switch (src_lo_rc) {
@@ -1489,18 +1773,31 @@ const bool Matcher::match_rule_supported(int opcode) {
   if (!has_match_rule(opcode)) {
     return false;
   }
+
+  switch (opcode) {
+    case Op_StrCompressedCopy: // fall through
+    case Op_StrInflatedCopy:   // fall through
+      return UseRVV;
+
+    case Op_EncodeISOArray:
+      return UseRVV && SpecialEncodeISOArray;
+
+    case Op_PopCountI:
+    case Op_PopCountL:
+      return UsePopCountInstruction;
+  }
+
   return true; // Per default match rules are supported.
 }
 
+// Identify extra cases that we might want to provide match rules for vector nodes and
+// other intrinsics guarded with vector length (vlen) and element type (bt).
 const bool Matcher::match_rule_supported_vector(int opcode, int vlen) {
+  if (!match_rule_supported(opcode)) {
+    return false;
+  }
 
-  // TODO
-  // identify extra cases that we might want to provide match rules for
-  // e.g. Op_ vector nodes and other intrinsics while guarding with vlen
-  bool ret_value = match_rule_supported(opcode);
-  // Add rules here.
-
-  return ret_value;  // Per default match rules are supported.
+  return op_vec_supported(opcode);
 }
 
 const bool Matcher::has_predicated_vectors(void) {
@@ -1574,12 +1871,17 @@ const int Matcher::min_vector_size(const BasicType bt) {
 
 // Vector ideal reg.
 const uint Matcher::vector_ideal_reg(int len) {
+  assert(MaxVectorSize >= len, "");
+  if (UseRVV) {
+    return Op_VecX;
+  }
+
   ShouldNotReachHere();
   return 0;
 }
 
 const uint Matcher::vector_shift_count_ideal_reg(int size) {
-  ShouldNotReachHere();
+  ShouldNotReachHere();  // Not supported
   return 0;
 }
 
@@ -1595,8 +1897,6 @@ const bool Matcher::misaligned_vectors_ok() {
 
 // false => size gets scaled to BytesPerLong, ok.
 const bool Matcher::init_array_count_is_in_bytes = false;
-
-// TODO: wind: too much  ----------------
 
 // Use conditional move (CMOVL)
 const int Matcher::long_cmove_cost() {
@@ -1677,8 +1977,6 @@ bool Matcher::float_in_double() { return false; }
 // the whole long is written but de-opt'ing will have to extract
 // the relevant 32 bits.
 const bool Matcher::int_in_long = true;
-
-// TODO: wind: too much  ----------------
 
 // Return whether or not this register is ever used as an argument.
 // This function is used on startup to build the trampoline stubs in
@@ -3108,6 +3406,67 @@ operand fRegD()
   constraint(ALLOC_IN_RC(double_reg));
   match(RegD);
 
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// Generic vector class. This will be used for
+// all vector operands.
+operand vReg()
+%{
+  constraint(ALLOC_IN_RC(vectorx_reg));
+  match(VecX);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V1()
+%{
+  constraint(ALLOC_IN_RC(v1_reg));
+  match(VecX);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V2()
+%{
+  constraint(ALLOC_IN_RC(v2_reg));
+  match(VecX);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V3()
+%{
+  constraint(ALLOC_IN_RC(v3_reg));
+  match(VecX);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V4()
+%{
+  constraint(ALLOC_IN_RC(v4_reg));
+  match(VecX);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V5()
+%{
+  constraint(ALLOC_IN_RC(v5_reg));
+  match(VecX);
+  match(vReg);
   op_cost(0);
   format %{ %}
   interface(REG_INTER);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1,0 +1,324 @@
+//
+// Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2020, Arm Limited. All rights reserved.
+// Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+//
+
+// RISCV Vector Extension Architecture Description File
+
+opclass vmemA(indirect);
+
+source_hpp %{
+  bool op_vec_supported(int opcode);
+%}
+
+source %{
+
+  static void loadStore(MacroAssembler masm, bool is_store,
+                        VectorRegister reg, BasicType bt, Register base) {
+    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
+    masm.vsetvli(t0, x0, sew);
+    if (is_store) {
+      masm.vsex_v(reg, base, sew);
+    } else {
+      masm.vlex_v(reg, base, sew);
+    }
+  }
+
+  bool op_vec_supported(int opcode) {
+    switch (opcode) {
+      // No multiply reduction instructions
+      case Op_MulReductionVD:
+      case Op_MulReductionVF:
+      case Op_MulReductionVI:
+      case Op_MulReductionVL:
+      // Others
+      case Op_Extract:
+      case Op_ExtractB:
+      case Op_ExtractC:
+      case Op_ExtractD:
+      case Op_ExtractF:
+      case Op_ExtractI:
+      case Op_ExtractL:
+      case Op_ExtractS:
+      case Op_ExtractUB:
+      // Vector API specific
+      case Op_AddReductionVI:
+      case Op_AddReductionVL:
+      case Op_AddReductionVF:
+      case Op_AddReductionVD:
+      case Op_OrV:
+      case Op_XorV:
+      case Op_ReplicateB:
+      case Op_ReplicateS:
+      case Op_ReplicateI:
+      case Op_ReplicateL:
+      case Op_ReplicateF:
+      case Op_ReplicateD:
+      case Op_PopCountI:
+      case Op_PopCountL:
+      case Op_PopCountVI:
+        /* may not enough */
+        return false;
+      default:
+        return UseRVV;
+    }
+  }
+
+%}
+
+definitions %{
+  int_def VEC_COST             (200, 200);
+%}
+
+// All VEC instructions
+
+// vector load/store
+instruct loadV(vReg dst, vmemA mem) %{
+  match(Set dst (LoadVector mem));
+  ins_cost(VEC_COST);
+  format %{ "vle $dst, $mem\t#@loadV" %}
+  ins_encode %{
+    VectorRegister dst_reg = as_VectorRegister($dst$$reg);
+    loadStore(MacroAssembler(&cbuf), false, dst_reg,
+              Matcher::vector_element_basic_type(this), as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct storeV(vReg src, vmemA mem) %{
+  match(Set mem (StoreVector mem src));
+  ins_cost(VEC_COST);
+  format %{ "vse $src, $mem\t#@storeV" %}
+  ins_encode %{
+    VectorRegister src_reg = as_VectorRegister($src$$reg);
+    loadStore(MacroAssembler(&cbuf), true, src_reg,
+              Matcher::vector_element_basic_type(this, $src), as_Register($mem$$base));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
+                         iRegI_R10 result, vReg_V1 v1,
+                         vReg_V2 v2, vReg_V3 v3, rFlagsReg cr)
+%{
+  predicate(UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
+  match(Set result (StrEquals (Binary str1 str2) cnt));
+  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP v1, TEMP v2, TEMP v3, KILL cr);
+
+  format %{ "V String Equals $str1, $str2, $cnt -> $result\t#@vstring_equalsL" %}
+  ins_encode %{
+    // Count is in 8-bit bytes; non-Compact chars are 16 bits.
+    __ string_equals_v($str1$$Register, $str2$$Register,
+                       $result$$Register, $cnt$$Register, 1);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct vstring_equalsU(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
+                         iRegI_R10 result, vReg_V1 v1,
+                         vReg_V2 v2, vReg_V3 v3, rFlagsReg cr)
+%{
+  predicate(UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::UU);
+  match(Set result (StrEquals (Binary str1 str2) cnt));
+  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP v1, TEMP v2, TEMP v3, KILL cr);
+
+  format %{ "V String Equals $str1, $str2, $cnt -> $result\t#@vstring_equalsU" %}
+  ins_encode %{
+    // Count is in 8-bit bytes; non-Compact chars are 16 bits.
+    __ string_equals_v($str1$$Register, $str2$$Register,
+                       $result$$Register, $cnt$$Register, 2);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct varray_equalsB(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
+                        vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegP_R28 tmp, rFlagsReg cr)
+%{
+  predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
+  match(Set result (AryEq ary1 ary2));
+  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v1, TEMP v2, TEMP v3, KILL cr);
+
+  format %{ "V Array Equals $ary1, ary2 -> $result\t#@varray_equalsB // KILL $tmp" %}
+  ins_encode %{
+    __ arrays_equals_v($ary1$$Register, $ary2$$Register,
+                       $result$$Register, $tmp$$Register, 1);
+    %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct varray_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
+                        vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegP_R28 tmp, rFlagsReg cr)
+%{
+  predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
+  match(Set result (AryEq ary1 ary2));
+  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v1, TEMP v2, TEMP v3, KILL cr);
+
+  format %{ "V Array Equals $ary1, ary2 -> $result\t#@varray_equalsC // KILL $tmp" %}
+  ins_encode %{
+    __ arrays_equals_v($ary1$$Register, $ary2$$Register,
+                       $result$$Register, $tmp$$Register, 2);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
+                          iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegP_R28 tmp1, iRegL_R29 tmp2)
+%{
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
+  match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
+  effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
+         TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+
+  format %{ "V String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@vstring_compareU" %}
+  ins_encode %{
+    // Count is in 8-bit bytes; non-Compact chars are 16 bits.
+    __ string_compare_v($str1$$Register, $str2$$Register,
+                        $cnt1$$Register, $cnt2$$Register, $result$$Register,
+                        $tmp1$$Register, $tmp2$$Register,
+                        StrIntrinsicNode::UU);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+instruct vstring_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
+                          iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegP_R28 tmp1, iRegL_R29 tmp2)
+%{
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
+  match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
+  effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
+         TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+
+  format %{ "V String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@vstring_compareL" %}
+  ins_encode %{
+    __ string_compare_v($str1$$Register, $str2$$Register,
+                        $cnt1$$Register, $cnt2$$Register, $result$$Register,
+                        $tmp1$$Register, $tmp2$$Register,
+                        StrIntrinsicNode::LL);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct vstring_compareUL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
+                           iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                           iRegP_R28 tmp1, iRegL_R29 tmp2)
+%{
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UL);
+  match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
+  effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
+         TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+
+  format %{"V String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@vstring_compareUL" %}
+  ins_encode %{
+    __ string_compare_v($str1$$Register, $str2$$Register,
+                        $cnt1$$Register, $cnt2$$Register, $result$$Register,
+                        $tmp1$$Register, $tmp2$$Register,
+                        StrIntrinsicNode::UL);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+instruct vstring_compareLU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
+                           iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                           iRegP_R28 tmp1, iRegL_R29 tmp2)
+%{
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LU);
+  match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
+  effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
+         TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+
+  format %{ "V String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@vstring_compareLU" %}
+  ins_encode %{
+    __ string_compare_v($str1$$Register, $str2$$Register,
+                        $cnt1$$Register, $cnt2$$Register, $result$$Register,
+                        $tmp1$$Register, $tmp2$$Register,
+                        StrIntrinsicNode::LU);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+// fast byte[] to char[] inflation
+instruct vstring_inflate(Universe dummy, iRegP_R10 src, iRegP_R11 dst, iRegI_R12 len,
+                         vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegLNoSp tmp)
+%{
+  predicate(UseRVV);
+  match(Set dummy (StrInflatedCopy src (Binary dst len)));
+  effect(TEMP v1, TEMP v2, TEMP v3, TEMP tmp, USE_KILL src, USE_KILL dst, USE_KILL len);
+
+  format %{ "V String Inflate $src,$dst" %}
+  ins_encode %{
+    __ byte_array_inflate_v($src$$Register, $dst$$Register, $len$$Register, $tmp$$Register);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+// encode char[] to byte[] in ISO_8859_1
+instruct vencode_iso_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10 result,
+                           vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegLNoSp tmp)
+%{
+  predicate(UseRVV);
+  match(Set result (EncodeISOArray src (Binary dst len)));
+  effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
+         TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
+
+  format %{ "V Encode array $src,$dst,$len -> $result" %}
+  ins_encode %{
+    __ encode_iso_array_v($src$$Register, $dst$$Register, $len$$Register,
+                          $result$$Register, $tmp$$Register);
+  %}
+  ins_pipe( pipe_class_memory );
+%}
+
+// fast char[] to byte[] compression
+instruct vstring_compress(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10 result,
+                          vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegLNoSp tmp)
+%{
+  predicate(UseRVV);
+  match(Set result (StrCompressedCopy src (Binary dst len)));
+  effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
+         TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
+
+  format %{ "V String Compress $src,$dst -> $result    // KILL R11, R12, R13" %}
+  ins_encode %{
+    __ char_array_compress_v($src$$Register, $dst$$Register, $len$$Register,
+                             $result$$Register, $tmp$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+// clearing of an array
+instruct vclearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, Universe dummy,
+                             vReg_V1 vReg1, vReg_V2 vReg2, vReg_V3 vReg3)
+%{
+  predicate(UseRVV);
+  match(Set dummy (ClearArray cnt base));
+  effect(USE_KILL cnt, USE_KILL base, TEMP vReg1, TEMP vReg2, TEMP vReg3);
+
+  format %{ "V ClearArray $cnt, $base\t#@clearArray_reg_reg" %}
+
+  ins_encode %{
+    __ clear_array_v($base$$Register, $cnt$$Register);
+  %}
+
+  ins_pipe(pipe_class_memory);
+%}

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -824,8 +824,56 @@ class StubGenerator: public StubCodeGenerator {
 
   typedef void (MacroAssembler::*copy_insn)(Register Rd, const Address &adr, Register temp);
 
+  void copy_memory_v(Register s, Register d, Register count, Register tmp, int step) {
+    bool is_backward = step < 0;
+    int granularity = uabs(step);
+
+    const Register src = x30, dst = x31, vl = x14, cnt = x15, tmp1 = x16, tmp2 = x17;
+    assert_different_registers(s, d, cnt, vl, tmp, tmp1, tmp2);
+    Assembler::SEW sew = Assembler::elemBytes_to_sew(granularity);
+    Label loop_forward, loop_backward, done;
+
+    __ mv(dst, d);
+    __ mv(src, s);
+    __ mv(cnt, count);
+
+    __ bind(loop_forward);
+    __ vsetvli(vl, cnt, sew, Assembler::m8);
+    if (is_backward) {
+      __ bne(vl, cnt, loop_backward);
+    }
+
+    __ vlex_v(v0, src, sew);
+    __ sub(cnt, cnt, vl);
+    __ slli(vl, vl, (int)sew);
+    __ add(src, src, vl);
+
+    __ vsex_v(v0, dst, sew);
+    __ add(dst, dst, vl);
+    __ bnez(cnt, loop_forward);
+
+    if (is_backward) {
+      __ j(done);
+
+      __ bind(loop_backward);
+      __ sub(tmp, cnt, vl);
+      __ slli(tmp, tmp, sew);
+      __ add(tmp1, s, tmp);
+      __ vlex_v(v0, tmp1, sew);
+      __ add(tmp2, d, tmp);
+      __ vsex_v(v0, tmp2, sew);
+      __ sub(cnt, cnt, vl);
+      __ bnez(cnt, loop_forward);
+      __ bind(done);
+    }
+  }
+
   void copy_memory(bool is_aligned, Register s, Register d,
                    Register count, Register tmp, int step) {
+
+    if (UseRVV) {
+      return copy_memory_v(s, d, count, tmp, step);
+    }
 
     bool is_backwards = step < 0;
     int granularity = uabs(step);

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -38,7 +38,39 @@ public:
   static void initialize();
 
 protected:
+  static const char* _uarch;
+  static uint32_t _initial_vector_length;
   static void get_processor_features();
+  static uint32_t get_current_vector_length();
+  static void get_os_cpu_info();
+
+  enum Feature_Flag {
+#define CPU_FEATURE_FLAGS(decl)             \
+  decl(I,            "i",            8)     \
+  decl(M,            "m",           12)     \
+  decl(A,            "a",            0)     \
+  decl(F,            "f",            5)     \
+  decl(D,            "d",            3)     \
+  decl(C,            "c",            2)     \
+  decl(V,            "v",           21)
+
+#define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1 << bit),
+      CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)
+#undef DECLARE_CPU_FEATURE_FLAG
+  };
+
+public:
+  static bool is_checkvext_fault(address pc) {
+    return pc != NULL && pc == _checkvext_fault_pc;
+  }
+
+  static address continuation_for_checkvext_fault(address pc) {
+    assert(_checkvext_continuation_pc != NULL, "not initialized");
+    return _checkvext_continuation_pc;
+  }
+
+  static address _checkvext_fault_pc;
+  static address _checkvext_continuation_pc;
 
 #ifdef COMPILER2
 private:

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -423,6 +423,14 @@ JVM_handle_linux_signal(int sig,
       }
     }
 
+    if (sig == SIGILL && VM_Version::is_checkvext_fault(pc)) {
+      warning("RVV is not supported on this CPU");
+      FLAG_SET_DEFAULT(UseRVV, false);
+      FLAG_SET_DEFAULT(UseRVV071, false);
+      os::Posix::ucontext_set_pc(uc, VM_Version::continuation_for_checkvext_fault(pc));
+      return true;
+    }
+
     if (thread->thread_state() == _thread_in_Java) {
       // Java thread running in Java code => find exception handler if any
       // a fault inside compiled code, the interpreter, or a stub

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -970,6 +970,17 @@ static void match_alias_type(Compile* C, Node* n, Node* m) {
 }
 #endif
 
+BasicType Matcher::vector_element_basic_type(const Node* n) {
+  const TypeVect* vt = n->bottom_type()->is_vect();
+  return vt->element_basic_type();
+}
+
+BasicType Matcher::vector_element_basic_type(const MachNode* use, const MachOper* opnd) {
+  int def_idx = use->operand_index(opnd);
+  Node* def = use->in(def_idx);
+  return def->bottom_type()->is_vect()->element_basic_type();
+}
+
 //------------------------------xform------------------------------------------
 // Given a Node in old-space, Match him (Label/Reduce) to produce a machine
 // Node in new-space.  Given a new-space Node, recursively walk his children.

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -337,6 +337,10 @@ public:
   static const uint vector_ideal_reg(int len);
   static const uint vector_shift_count_ideal_reg(int len);
 
+  // Vector element basic type
+  static BasicType vector_element_basic_type(const Node* n);
+  static BasicType vector_element_basic_type(const MachNode* use, const MachOper* opnd);
+
   // CPU supports misaligned vectors store/load.
   static const bool misaligned_vectors_ok();
 


### PR DESCRIPTION
We can enable the vector extension on real boards after this adaptation.