### PR TITLE
[Wisp] Adapt `Thread.stackSize`

### DIFF
--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/TaskDispatcher.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/TaskDispatcher.java
@@ -29,13 +29,15 @@ class TaskDispatcher implements StealAwareRunnable {
     private final Runnable target;
     private final String name;
     private final Thread thread;
+    private final long stackSize;
 
-    TaskDispatcher(ClassLoader ctxClassLoader, Runnable target, String name, Thread thread) {
+    TaskDispatcher(ClassLoader ctxClassLoader, Runnable target, String name, Thread thread, long stackSize) {
         this.ctxClassLoader = ctxClassLoader;
         this.enqueueTime = WispEngine.getNanoTime();
         this.target = target;
         this.name = name;
         this.thread = thread;
+        this.stackSize = stackSize;
     }
 
     @Override
@@ -43,6 +45,7 @@ class TaskDispatcher implements StealAwareRunnable {
         WispCarrier current = WispCarrier.current();
         current.countEnqueueTime(enqueueTime);
         current.runTaskInternal(target, name, thread,
-                ctxClassLoader == null ? current.current.ctxClassLoader : ctxClassLoader);
+                ctxClassLoader == null ? current.current.ctxClassLoader : ctxClassLoader,
+                this.stackSize);
     }
 }

--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/ThreadAsWisp.java
@@ -51,7 +51,7 @@ class ThreadAsWisp {
      * @param target thread's target field
      * @return if condition is satisfied and thread is started as wisp
      */
-    static boolean tryStart(Thread thread, Runnable target) {
+    static boolean tryStart(Thread thread, Runnable target, long stackSize) {
         if (WispEngine.isEngineThread(thread)) {
             return false;
         }
@@ -75,7 +75,7 @@ class ThreadAsWisp {
 
         // pthread_create always return before new thread started, so we should not wait here
         WispEngine.JLA.setWispAlive(thread, true); // thread.isAlive() should be true
-        WispEngine.current().startAsThread(thread, thread.getName(), thread);
+        WispEngine.current().startAsThread(thread, thread.getName(), thread, stackSize);
         return true;
     }
 

--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispCarrier.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispCarrier.java
@@ -91,7 +91,7 @@ final class WispCarrier implements Comparable<WispCarrier> {
         CoroutineSupport cs = thread.getCoroutineSupport();
         current = threadTask = new WispTask(this,
                 cs == null ? null : cs.threadCoroutine(),
-                cs != null, true);
+                cs != null, true, WispConfiguration.STACK_SIZE);
         if (cs == null) { // fake carrier used in jni attach
             threadTask.setThreadWrapper(thread);
         } else {
@@ -129,7 +129,7 @@ final class WispCarrier implements Comparable<WispCarrier> {
 
     // ----------------------------------------------- lifecycle
 
-    final WispTask runTaskInternal(Runnable target, String name, Thread thread, ClassLoader ctxLoader) {
+    final WispTask runTaskInternal(Runnable target, String name, Thread thread, ClassLoader ctxLoader, long stackSize) {
         if (engine.hasBeenShutdown && !WispTask.SHUTDOWN_TASK_NAME.equals(name)) {
             throw new RejectedExecutionException("Wisp carrier has been shutdown");
         }
@@ -139,8 +139,8 @@ final class WispCarrier implements Comparable<WispCarrier> {
         WispTask wispTask;
         try {
             counter.incrementCreateTaskCount();
-            if ((wispTask = getTaskFromCache()) == null) {
-                wispTask = new WispTask(this, null, true, false);
+            if ((wispTask = getTaskFromCache(stackSize)) == null) {
+                wispTask = new WispTask(this, null, true, false, stackSize);
                 WispTask.trackTask(wispTask);
             }
             wispTask.reset(target, name, thread, ctxLoader);
@@ -186,9 +186,15 @@ final class WispCarrier implements Comparable<WispCarrier> {
     }
 
     /**
+     * @param stackSize of expected cached task,
+     *                  currently only default value ({@link WispConfiguration.STACK_SIZE}) is supported.
+     *                  see also returnTaskToCache(task)
      * @return task from global cached theScheduler
      */
-    private WispTask getTaskFromCache() {
+    private WispTask getTaskFromCache(long stackSize) {
+        if (stackSize != WispConfiguration.STACK_SIZE) {
+            return null;
+        }
         assert WispCarrier.current() == this;
         if (!taskCache.isEmpty()) {
             return taskCache.remove(taskCache.size() - 1);
@@ -215,6 +221,12 @@ final class WispCarrier implements Comparable<WispCarrier> {
      * cache will return false.
      */
     private boolean returnTaskToCache(WispTask task) {
+        // if the stack size of this task is not default,
+        // do not cache and reuse it.
+        // see also getTaskFromCache(long)
+        if (task.stackSize != WispConfiguration.STACK_SIZE) {
+            return false;
+        }
         // reuse exited wispTasks from shutdown wispEngine is very tricky, so we'd better not return
         // these tasks to global cache
         if (taskCache.size() > WispConfiguration.WISP_ENGINE_TASK_CACHE_SIZE && !engine.hasBeenShutdown) {

--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -319,8 +319,9 @@ public class WispEngine extends AbstractExecutorService {
             }
 
             @Override
-            public boolean tryStartThreadAsWisp(Thread thread, Runnable target) {
-                return ThreadAsWisp.tryStart(thread, target);
+            public boolean tryStartThreadAsWisp(Thread thread, Runnable target, long stackSize) {
+                // Thread uses 0 as the default stack size.
+                return ThreadAsWisp.tryStart(thread, target, stackSize == 0 ? WispConfiguration.STACK_SIZE : stackSize);
             }
 
             @Override
@@ -515,7 +516,7 @@ public class WispEngine extends AbstractExecutorService {
         public void run() {
             WispCarrier.current().runTaskInternal(
                     wispControlGroup == null ? new ShutdownEngine() : new ShutdownControlGroup(wispControlGroup),
-                    WispTask.SHUTDOWN_TASK_NAME, null, null);
+                    WispTask.SHUTDOWN_TASK_NAME, null, null, WispConfiguration.STACK_SIZE);
         }
     }
 
@@ -628,7 +629,7 @@ public class WispEngine extends AbstractExecutorService {
     @Override
     public void execute(Runnable command) {
         scheduler.execute(new TaskDispatcher(WispCarrier.current().current.ctxClassLoader,
-                command, "execute task", null));
+                command, "execute task", null, WispConfiguration.STACK_SIZE));
     }
 
     public List<Long> getWispCarrierIds() {
@@ -660,9 +661,9 @@ public class WispEngine extends AbstractExecutorService {
         });
     }
 
-    void startAsThread(Runnable target, String name, Thread thread) {
+    void startAsThread(Runnable target, String name, Thread thread, long stackSize) {
         scheduler.execute(new TaskDispatcher(WispCarrier.current().current.ctxClassLoader,
-                target, name, thread));
+                target, name, thread, stackSize));
     }
 
     private static native void registerNatives();

--- a/src/java.base/linux/classes/com/alibaba/wisp/engine/WispTask.java
+++ b/src/java.base/linux/classes/com/alibaba/wisp/engine/WispTask.java
@@ -181,12 +181,19 @@ public class WispTask implements Comparable<WispTask> {
 
     boolean shutdownPending;
 
+    final long stackSize;
+
     WispTask(WispCarrier carrier, Coroutine ctx, boolean isRealTask, boolean isThreadTask) {
+        this(carrier, ctx, isRealTask, isThreadTask, WispConfiguration.STACK_SIZE);
+    }
+
+    WispTask(WispCarrier carrier, Coroutine ctx, boolean isRealTask, boolean isThreadTask, long stackSize) {
         this.isThreadTask = isThreadTask;
         this.id = isRealTask ? idGenerator.addAndGet(1) : -1;
+        this.stackSize = stackSize;
         setCarrier(carrier);
         if (isRealTask) {
-            this.ctx = ctx != null ? ctx : new CacheableCoroutine(WispConfiguration.STACK_SIZE);
+            this.ctx = ctx != null ? ctx : new CacheableCoroutine(this.stackSize);
             this.ctx.setWispTask(id, this, carrier);
         } else {
             this.ctx = null;

--- a/src/java.base/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/macosx/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -145,7 +145,7 @@ public class WispEngine {
             }
 
             @Override
-            public boolean tryStartThreadAsWisp(Thread thread, Runnable target) {
+            public boolean tryStartThreadAsWisp(Thread thread, Runnable target, long stackSize) {
                 return false;
             }
 

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -919,7 +919,7 @@ class Thread implements Runnable {
         boolean started = false;
         try {
             if (!(WEA != null && WispEngine.enableThreadAsWisp() &&
-                    WEA.tryStartThreadAsWisp(this, target))) {
+                    WEA.tryStartThreadAsWisp(this, target, this.stackSize))) {
                 start0();
             }
             started = true;

--- a/src/java.base/share/classes/jdk/internal/misc/WispEngineAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/WispEngineAccess.java
@@ -52,7 +52,7 @@ public interface WispEngineAccess {
 
     boolean isAllThreadAsWisp();
 
-    boolean tryStartThreadAsWisp(Thread thread, Runnable target);
+    boolean tryStartThreadAsWisp(Thread thread, Runnable target, long stackSize);
 
     boolean useDirectSelectorWakeup();
 

--- a/src/java.base/windows/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/java.base/windows/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -144,7 +144,7 @@ public class WispEngine {
             }
 
             @Override
-            public boolean tryStartThreadAsWisp(Thread thread, Runnable target) {
+            public boolean tryStartThreadAsWisp(Thread thread, Runnable target, long stackSize) {
                 return false;
             }
 

--- a/test/jdk/com/alibaba/wisp2/Wisp2StackSizeTest.java
+++ b/test/jdk/com/alibaba/wisp2/Wisp2StackSizeTest.java
@@ -1,0 +1,62 @@
+/*
+ * @test
+ * @library /lib/testlibrary
+ * @summary test wisp2 stack_size
+ * @requires os.family == "linux"
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 Wisp2StackSizeTest
+ */
+
+
+import static jdk.testlibrary.Asserts.*;
+
+public class Wisp2StackSizeTest {
+    public static void main(String[] args) {
+        int prevDepth = 0, curDepth = 0;
+
+        for (int i = 128; i <= 1024; i *= 2) {
+            for (int j = 0; j < 10; j++) {
+                curDepth = Math.max(curDepth, RecTester.tryRec(i * 1024));
+            }
+
+            if (prevDepth != 0) {
+                // roughly curDepth / prevDepth ~= 2
+                assertTrue(Math.abs(curDepth - 2 * prevDepth) < prevDepth, i + " " + curDepth + " " + prevDepth);
+            }
+
+            prevDepth = curDepth;
+        }
+    }
+}
+
+class RecTester implements Runnable {
+    /**
+     * Run recursion on {@link Thread} with given stackSize.
+     *
+     * @return recursion depth before {@link StackOverflowError}
+     */
+    public static int tryRec(long stackSize) {
+        RecTester r = new RecTester();
+        Thread t = new Thread(null, r, "", stackSize);
+        t.start();
+        try {
+            t.join();
+        } catch (InterruptedException ignored) {
+        }
+        return r.depth;
+    }
+
+    public int depth = 0;
+
+    @Override
+    public void run() {
+        try {
+            inner();
+        } catch (StackOverflowError ignored) {
+        }
+    }
+
+    private void inner() {
+        depth++;
+        inner();
+    }
+}


### PR DESCRIPTION
Summary:
Previously wisp uses 512k as the stack size and ignores Thread.stackSize. This PR will make wisp to use Thread.stackSize as its stack size. Cherry-pick https://github.com/alibaba/dragonwell8/commit/e64b3fc40856483466e67e39b70ffcc938b74c64.

Test Plan: jtreg:com/jdk/alibaba/wisp2/

Reviewed-by: yuleil, zhengxiaolinX