### PR TITLE
[Misc] fix UnsafeIntrinsicsTest.java run OOM on same machine

### DIFF
--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -31,6 +31,7 @@
  * @library /test/lib
  * @run main/othervm -Xmx256m
  *                   -XX:+UseZGC
+ *                   -XX:ParallelGCThreads=5
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+ZVerifyViews -XX:ZCollectionInterval=1
  *                   -XX:-CreateCoredumpOnCrash


### PR DESCRIPTION
Summary: fix test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java run OOM on same machine

Test Plan: CI pipeline

Reviewed-by: lei.yul, qingfeng.yy

Issue: https://github.com/alibaba/dragonwell11/issues/267