### PR TITLE
[Backport] VectorAPI: 8236364: TEMP vector registers could be incorrectly assigned upper bank xmm registers after Generic Operands (JDK-8234391)

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2322,7 +2322,7 @@ const bool Matcher::need_masked_shift_count = false;
 // No support for generic vector operands.
 const bool Matcher::supports_generic_vector_operands  = false;
 
-MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
   return NULL;
 }

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1222,7 +1222,7 @@ const bool Matcher::convi2l_type_required = true;
 // No support for generic vector operands.
 const bool Matcher::supports_generic_vector_operands  = false;
 
-MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
   return NULL;
 }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2380,7 +2380,7 @@ const bool Matcher::need_masked_shift_count = true;
 // No support for generic vector operands.
 const bool Matcher::supports_generic_vector_operands  = false;
 
-MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
   return NULL;
 }

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1632,7 +1632,7 @@ const bool Matcher::need_masked_shift_count = false;
 // No support for generic vector operands.
 const bool Matcher::supports_generic_vector_operands  = false;
 
-MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
   return NULL;
 }

--- a/src/hotspot/cpu/sparc/sparc.ad
+++ b/src/hotspot/cpu/sparc/sparc.ad
@@ -1817,7 +1817,7 @@ const bool Matcher::need_masked_shift_count = false;
 // No support for generic vector operands.
 const bool Matcher::supports_generic_vector_operands  = false;
 
-MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg) {
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
   return NULL;
 }

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1587,9 +1587,14 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
 // x86 supports generic vector operands: vec and legVec.
 const bool Matcher::supports_generic_vector_operands = true;
 
-MachOper* Matcher::specialize_generic_vector_operand(MachOper* generic_opnd, uint ideal_reg) {
+MachOper* Matcher::specialize_generic_vector_operand(MachOper* generic_opnd, uint ideal_reg, bool is_temp) {
   assert(Matcher::is_generic_vector(generic_opnd), "not generic");
   bool legacy = (generic_opnd->opcode() == LEGVEC);
+  if (!VM_Version::supports_avx512vlbwdq() && // KNL
+      is_temp && !legacy && (ideal_reg == Op_VecZ)) {
+    // Conservatively specialize 512bit vec TEMP operands to legVecZ (zmm0-15) on KNL.
+    return new legVecZOper();
+  }
   if (legacy) {
     switch (ideal_reg) {
       case Op_VecS: return new legVecSOper();

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -2525,7 +2525,7 @@ MachOper* Matcher::specialize_vector_operand_helper(MachNode* m, MachOper* origi
     int size_in_bytes = 4 * type2size[t->basic_type()];
     ideal_reg = Matcher::vector_ideal_reg(size_in_bytes);
   }
-  return Matcher::specialize_generic_vector_operand(original_opnd, ideal_reg);
+  return Matcher::specialize_generic_vector_operand(original_opnd, ideal_reg, false);
 }
 
 // Compute concrete vector operand for a generic TEMP vector mach node based on its user info.
@@ -2537,7 +2537,7 @@ void Matcher::specialize_temp_node(MachTempNode* tmp, MachNode* use, uint idx) {
     tmp->_opnds[0] = use->_opnds[0]->clone();
   } else {
     uint ideal_vreg = vector_ideal_reg(C->max_vector_size());
-    tmp->_opnds[0] = specialize_generic_vector_operand(tmp->_opnds[0], ideal_vreg);
+    tmp->_opnds[0] = specialize_generic_vector_operand(tmp->_opnds[0], ideal_vreg, true);
   }
 }
 

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -527,7 +527,7 @@ public:
   MachOper* specialize_vector_operand(MachNode* m, uint idx);
   MachOper* specialize_vector_operand_helper(MachNode* m, MachOper* generic_opnd);
 
-  static MachOper* specialize_generic_vector_operand(MachOper* generic_opnd, uint ideal_reg);
+  static MachOper* specialize_generic_vector_operand(MachOper* generic_opnd, uint ideal_reg, bool is_temp);
 
   static bool is_generic_reg2reg_move(MachNode* m);
   static bool is_generic_vector(MachOper* opnd);


### PR DESCRIPTION
[Backport] VectorAPI: 8236364: TEMP vector registers could be incorrectly assigned upper bank xmm registers after Generic Operands (JDK-8234391)

Summary: Backport VectorAPI 8236364: TEMP vector registers could be incorrectly assigned upper bank xmm registers after Generic Operands (JDK-8234391)

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/300