### PR TITLE
[Misc] fix TestMiniDump.sh intermittently does not terminate java process when test finish

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/jmap-minidump/TestMiniDump.sh
+++ b/test/hotspot/jtreg/serviceability/sa/jmap-minidump/TestMiniDump.sh
@@ -63,13 +63,12 @@ if [ $? != '0' ]; then
     exit 1
 fi
 
-${JAVA} -cp . -Xmx4g -Xms4g -Xmn2g ${TEST_CLASS}&
-
+${JAVA} -cp . -Xmx4g -Xms4g -Xmn2g ${TEST_CLASS} &
+PID=$!
+if [ $? != 0 ] || [ -z "${PID}" ]; then exit 1; fi
+trap "kill -9 ${PID}" exit
 # wait child java process to allocate memory
 sleep 5
-
-PID=$(${JPS} | grep ${TEST_CLASS} | awk '{print $1}')
-if [ $? != 0 ] || [ -z "${PID}" ]; then exit 1; fi
 
 # full dump must be > 1G
 FULL_DUMP_SIZE_THRESHOLD=$(( 1024 * 1024 * 1024))

--- a/test/hotspot/jtreg/serviceability/sa/jmap-minidump/TestMiniHeapDumpOpts.sh
+++ b/test/hotspot/jtreg/serviceability/sa/jmap-minidump/TestMiniHeapDumpOpts.sh
@@ -60,8 +60,8 @@ EOF
 ${JAVAC} Loop.java
 if [ $? != 0 ]; then exit 1; fi
 
-${JAVA} -cp . Loop&
-PID=$(${JPS} | grep 'Loop' | awk '{print $1}')
+${JAVA} -cp . Loop &
+PID=$!
 if [ $? != 0 ] || [ -z "${PID}" ]; then exit 1; fi
 ${JMAP} -dump:format=b,mini,file=heap.bin ${PID}
 if [ $? != 0 ] || [ ! -f "${PWD}/heap.bin" ]; then exit 1; fi


### PR DESCRIPTION
Summary: fix TestMiniDump.sh intermittently does not terminate java process when test finish, especially test run fail

Test Plan: CI pipeline

Reviewed-by: albert.th, lvfei.lv

Issue: https://github.com/alibaba/dragonwell11/issues/306