### PR TITLE
[Misc] fix error get PID method in TestMiniHeapDumpOpts.sh and enable it

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/jmap-minidump/TestMiniHeapDumpOpts.sh
+++ b/test/hotspot/jtreg/serviceability/sa/jmap-minidump/TestMiniHeapDumpOpts.sh
@@ -19,7 +19,7 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-#
+# @test
 # @summary Test jmap options related to mini heap dump
 # @run shell/timeout=300 TestMiniHeapDumpOpts.sh
 #
@@ -63,10 +63,9 @@ if [ $? != 0 ]; then exit 1; fi
 ${JAVA} -cp . Loop &
 PID=$!
 if [ $? != 0 ] || [ -z "${PID}" ]; then exit 1; fi
+trap "kill -9 ${PID}" exit
+sleep 5
 ${JMAP} -dump:format=b,mini,file=heap.bin ${PID}
 if [ $? != 0 ] || [ ! -f "${PWD}/heap.bin" ]; then exit 1; fi
-
-kill -9 ${PID}
-if [ $? != 0 ]; then exit 1; fi
 
 exit 0


### PR DESCRIPTION
Summary: fix error get PID method in test/hotspot/jtreg/serviceability/sa/jmap-minidump/TestMiniHeapDumpOpts.sh and enable it

Test Plan: CI pipeline

Reviewed-by: albert.th, lvfei.lv

Issue: https://github.com/alibaba/dragonwell11/issues/308