### PR TITLE
[Misc] fix TestPreemptWisp2InternalBug.java intermittently fail

### DIFF
--- a/test/jdk/com/alibaba/wisp2/exclusive/bug/TestPreemptWisp2InternalBug.java
+++ b/test/jdk/com/alibaba/wisp2/exclusive/bug/TestPreemptWisp2InternalBug.java
@@ -27,9 +27,20 @@ public class TestPreemptWisp2InternalBug {
 				        "-XX:+UseWisp2", "-XX:+UnlockDiagnosticVMOptions", "-XX:+VerboseWisp", "-XX:-Inline",
                         "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
 				        TestPreemptWisp2InternalBug.class.getName(), tasks[i]);
-		        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-		        output.shouldContain("[WISP] preempt was blocked, because wisp internal method on the stack");
-	        }
+				int count = 0;
+				for (int j = 0; j < 4; j++) {
+					try {
+						OutputAnalyzer output = new OutputAnalyzer(pb.start());
+						output.shouldContain("[WISP] preempt was blocked, because wisp internal method on the stack");
+						break;
+					} catch (java.lang.RuntimeException e) {
+						count++;
+					}
+				}
+				if(count >= 2) {
+					throw new RuntimeException("Test " + tasks[i] + "run 5 times, failed " + count + " times!");
+				}
+			}
             return;
         }
 


### PR DESCRIPTION
Summary: fix com/alibaba/wisp2/exclusive/bug/TestPreemptWisp2InternalBug.java intermittently fail, run 4 times in a test, if 2 times or more can not match the expect message, then the test is fail.

Test Plan: CI pipeline

Reviewed-by: yunyao.zxl, lei.yul

Issue: https://github.com/alibaba/dragonwell11/issues/313