### PR TITLE
[Misc] fix UnsafeIntrinsicsTest.java run OOM on same machine and revert commit 9e37ea4aa6ebd5eb7510d08c957b6c8d577bb890

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -95,7 +95,6 @@ gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8193639 solaris-all
 gc/stress/gcbasher/TestGCBasherWithCMS.java 8272195 generic-i586
 gc/cms/TestBubbleUpRef.java  8272195 generic-i586
 gc/stress/gcold/TestGCOldWithCMS.java 8272195 generic-i586
-compiler/gcbarriers/UnsafeIntrinsicsTest.java#z https://github.com/alibaba/dragonwell11/issues/267 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -32,6 +32,7 @@
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:+UseZGC
+ *                   -XX:ParallelGCThreads=5
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+ZUnmapBadViews -XX:ZCollectionInterval=1
  *                   -XX:-CreateCoredumpOnCrash


### PR DESCRIPTION
Summary: fix test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java run OOM on same machine, and revert commit 9e37ea4aa6ebd5eb7510d08c957b6c8d577bb890

Test Plan: CI pipeline

Reviewed-by: kuaiwei.kw, lvfei.lv

Issue: https://github.com/alibaba/dragonwell11/issues/267