### PR TITLE
[Misc] Fix ported TestLibmIntrinsics.java

### DIFF
--- a/test/hotspot/jtreg/compiler/floatingpoint/TestLibmIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/TestLibmIntrinsics.java
@@ -27,8 +27,9 @@
  * @summary Test libm intrinsics
  * @library /test/lib /
  *
- * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:-BackgroundCompilation -XX:-UseOnStackReplacement
  *                   compiler.floatingpoint.TestLibmIntrinsics
@@ -37,7 +38,7 @@
 package compiler.floatingpoint;
 
 import compiler.whitebox.CompilerWhiteBoxTest;
-import jdk.test.whitebox.WhiteBox;
+import sun.hotspot.WhiteBox;
 
 import java.lang.reflect.Method;
 


### PR DESCRIPTION
Summary: Fix a test to pass the GHA checks.

Test Plan: test/hotspot/jtreg/compiler/floatingpoint/TestLibmIntrinsics.java

Reviewed-by: kuaiwei

Issue: #209