### PR TITLE
[Wisp] WispThreadCompositeData.getCompositeData() should use legal Thread State String

### DIFF
--- a/src/java.management/share/classes/sun/management/ThreadImpl.java
+++ b/src/java.management/share/classes/sun/management/ThreadImpl.java
@@ -26,6 +26,7 @@
 package sun.management;
 
 import com.alibaba.wisp.engine.WispEngine;
+import com.alibaba.wisp.engine.WispTask;
 import jdk.internal.misc.SharedSecrets;
 import jdk.internal.misc.WispEngineAccess;
 
@@ -206,7 +207,11 @@ public class ThreadImpl implements ThreadMXBean {
         if (WispEngine.enableThreadAsWisp()) {
             for (int i = 0; i < infos.length; i++) {
                 if (infos[i] == null) {
-                    infos[i] = ThreadInfo.from(new WispThreadCompositeData(WEA.getWispTaskById(ids[i])));
+                    WispTask task = WEA.getWispTaskById(ids[i]);
+                    if (task == null) {
+                        continue;
+                    }
+                    infos[i] = ThreadInfo.from(new WispThreadCompositeData(task));
                 }
             }
         }

--- a/src/java.management/share/classes/sun/management/WispThreadCompositeData.java
+++ b/src/java.management/share/classes/sun/management/WispThreadCompositeData.java
@@ -16,17 +16,18 @@ public class WispThreadCompositeData extends LazyCompositeData {
     private final WispTask task;
 
     public WispThreadCompositeData(WispTask wispTask) {
+        assert wispTask != null : "handled null cases already";
         task = wispTask;
     }
 
     @Override
     protected CompositeData getCompositeData() {
         Map<String, Object> items = new HashMap<>();
-        Thread t = task != null ? task.getThreadWrapper() : null;
+        Thread t = task.getThreadWrapper();
         Object parkBlocker = t != null ? LockSupport.getBlocker(t) : null;
         items.put(THREAD_ID,        t != null ? t.getId() : 0L);
         items.put(THREAD_NAME,      t != null ? t.getName() : "");
-        items.put(THREAD_STATE,     t != null ? t.getState().name() : "");
+        items.put(THREAD_STATE,     t != null ? t.getState().name() : Thread.State.TERMINATED.toString());
         items.put(LOCK_NAME,        parkBlocker == null ? "" : parkBlocker.toString());
         items.put(BLOCKED_TIME,     0L);
         items.put(BLOCKED_COUNT,    0L);


### PR DESCRIPTION
Summary: sun.management.ThreadInfoCompositeData.threadState() will use valueOf() to read Thread.State String. We should specify a TERMINATED String for it. Also, a cleanup.

Test Plan: com/alibaba/wisp/thread/TestThreadInfo.java

Reviewed-by: D-D-H, yuleil

Issue: #345