### PR TITLE
[Backport] 8241042: x86_64: Improve Assembler generation. 

### DIFF
--- a/src/hotspot/share/asm/assembler.hpp
+++ b/src/hotspot/share/asm/assembler.hpp
@@ -278,14 +278,21 @@ class AbstractAssembler : public ResourceObj  {
   // ensure buf contains all code (call this before using/copying the code)
   void flush();
 
-  void emit_int8(   int8_t  x) { code_section()->emit_int8(   x); }
-  void emit_int16(  int16_t x) { code_section()->emit_int16(  x); }
-  void emit_int32(  int32_t x) { code_section()->emit_int32(  x); }
-  void emit_int64(  int64_t x) { code_section()->emit_int64(  x); }
+  void emit_int8(   int8_t x1)                                  { code_section()->emit_int8(x1); }
 
-  void emit_float(  jfloat  x) { code_section()->emit_float(  x); }
-  void emit_double( jdouble x) { code_section()->emit_double( x); }
-  void emit_address(address x) { code_section()->emit_address(x); }
+  void emit_int16(  int16_t x)                                  { code_section()->emit_int16(x); }
+  void emit_int16(  int8_t x1, int8_t x2)                       { code_section()->emit_int16(x1, x2); }
+
+  void emit_int24(  int8_t x1, int8_t x2, int8_t x3)            { code_section()->emit_int24(x1, x2, x3); }
+
+  void emit_int32(  int32_t x)                                  { code_section()->emit_int32(x); }
+  void emit_int32(  int8_t x1, int8_t x2, int8_t x3, int8_t x4) { code_section()->emit_int32(x1, x2, x3, x4); }
+
+  void emit_int64(  int64_t x)                                  { code_section()->emit_int64(x); }
+
+  void emit_float(  jfloat  x)                                  { code_section()->emit_float(x); }
+  void emit_double( jdouble x)                                  { code_section()->emit_double(x); }
+  void emit_address(address x)                                  { code_section()->emit_address(x); }
 
   enum { min_simm10 = -512 };
 

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -200,9 +200,38 @@ class CodeSection {
   }
 
   // Code emission
-  void emit_int8 ( int8_t  x)  { *((int8_t*)  end()) = x; set_end(end() + sizeof(int8_t)); }
-  void emit_int16( int16_t x)  { *((int16_t*) end()) = x; set_end(end() + sizeof(int16_t)); }
-  void emit_int32( int32_t x)  { *((int32_t*) end()) = x; set_end(end() + sizeof(int32_t)); }
+  void emit_int8(int8_t x1) {
+    address curr = end();
+    *((int8_t*)  curr++) = x1;
+    set_end(curr);
+  }
+
+  void emit_int16(int16_t x) { *((int16_t*) end()) = x; set_end(end() + sizeof(int16_t)); }
+  void emit_int16(int8_t x1, int8_t x2) {
+    address curr = end();
+    *((int8_t*)  curr++) = x1;
+    *((int8_t*)  curr++) = x2;
+    set_end(curr);
+  }
+
+  void emit_int24(int8_t x1, int8_t x2, int8_t x3)  {
+    address curr = end();
+    *((int8_t*)  curr++) = x1;
+    *((int8_t*)  curr++) = x2;
+    *((int8_t*)  curr++) = x3;
+    set_end(curr);
+  }
+
+  void emit_int32(int32_t x) { *((int32_t*) end()) = x; set_end(end() + sizeof(int32_t)); }
+  void emit_int32(int8_t x1, int8_t x2, int8_t x3, int8_t x4)  {
+    address curr = end();
+    *((int8_t*)  curr++) = x1;
+    *((int8_t*)  curr++) = x2;
+    *((int8_t*)  curr++) = x3;
+    *((int8_t*)  curr++) = x4;
+    set_end(curr);
+  }
+
   void emit_int64( int64_t x)  { *((int64_t*) end()) = x; set_end(end() + sizeof(int64_t)); }
 
   void emit_float( jfloat  x)  { *((jfloat*)  end()) = x; set_end(end() + sizeof(jfloat)); }


### PR DESCRIPTION
[Backport] 8241042: x86_64: Improve Assembler generation. 

Summary: 8241042: x86_64: Improve Assembler generation.  src/hotspot/cpu/x86/assembler_x86.cpp not included, only src/hotspot/share/asm/assembler.hpp and src/hotspot/share/asm/codeBuffer.hpp, for VectorAPI backport.

Test Plan: ci jtreg    

Reviewed-by: JoshuaZhuwj

Issue: #351 