### PR TITLE
[Backport] 8242073: x86_32 build failure after JDK-8241040

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -3402,6 +3402,15 @@ operand immI8() %{
   interface(CONST_INTER);
 %}
 
+operand immU8() %{
+  predicate((0 <= n->get_int()) && (n->get_int() <= 255));
+  match(ConI);
+
+  op_cost(5);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 operand immI16() %{
   predicate((-32768 <= n->get_int()) && (n->get_int() <= 32767));
   match(ConI);


### PR DESCRIPTION
Summary: Backport 8242073: x86_32 build failure after JDK-8241040

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/369