### PR TITLE
[Backport] 8218029: [TESTBUG] Use -Djava.class.path= to specify empty -cp in CDS tests

### DIFF
--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/NonBootLoaderClasses.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/NonBootLoaderClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,13 +46,13 @@ public class NonBootLoaderClasses {
             CDSTestUtils.makeClassList(classes).getPath();
         String archiveName = "NonBootLoaderClasses.jsa";
         CDSOptions opts = (new CDSOptions())
-            .addPrefix("-XX:ExtraSharedClassListFile=" + classList, "-cp", "\"\"")
+            .addPrefix("-XX:ExtraSharedClassListFile=" + classList, "-Djava.class.path=")
             .setArchiveName(archiveName);
         CDSTestUtils.createArchiveAndCheck(opts);
 
         // Print the shared dictionary and inspect the output
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                "-cp", "\"\"",
+                "-Djava.class.path=",
                 "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./" + archiveName,
                 "-XX:+PrintSharedArchiveAndExit", "-XX:+PrintSharedDictionary");
         OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "print-shared-archive");

--- a/test/hotspot/jtreg/runtime/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/appcds/TestCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,8 +131,7 @@ public class TestCommon extends CDSTestUtils {
             cmd.add("-cp");
             cmd.add(opts.appJar);
         } else {
-            cmd.add("-cp");
-            cmd.add("\"\"");
+            cmd.add("-Djava.class.path=");
         }
 
         cmd.add("-Xshare:dump");

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddModules.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class AddModules {
                                         "--add-modules",
                                         MAIN_MODULE1 + "," + MAIN_MODULE2);
         TestCommon.checkDump(output);
-        String prefix[] = {"-cp", "\"\"", "-Xlog:class+load=trace"};
+        String prefix[] = {"-Djava.class.path=", "-Xlog:class+load=trace"};
 
         // run the com.greetings module with the archive with the --module-path
         // the same as the one during dump time.

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddReads.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddReads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ public class AddReads {
                                         "--add-reads", "com.norequires=org.astro",
                                         "-m", MAIN_MODULE);
         TestCommon.checkDump(output);
-        String prefix[] = {"-cp", "\"\"", "-Xlog:class+load=trace",
+        String prefix[] = {"-Djava.class.path=", "-Xlog:class+load=trace",
                            "--add-modules", SUB_MODULE,
                            "--add-reads", "com.norequires=org.astro"};
 

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ModulePathAndCP.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ModulePathAndCP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/overridetests/OverrideTests.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/overridetests/OverrideTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,11 +159,10 @@ public class OverrideTests {
         boolean isAppLoader = loaderName.equals("app");
         int upgradeModIdx = isAppLoader ? 0 : 1;
         String expectedException = "java.lang.module.FindException: Unable to compute the hash";
-        String prefix[] = new String[4];
-        prefix[0] = "-cp";
-        prefix[1] = "\"\"";
-        prefix[2] = "--add-modules";
-        prefix[3] = "java.net.http";
+        String prefix[] = new String[3];
+        prefix[0] = "-Djava.class.path=";
+        prefix[1] = "--add-modules";
+        prefix[2] = "java.net.http";
 
         // Run the test with --upgrade-module-path set to alternate location of archiveClass
         // The alternate version of archiveClass SHOULD be found.


### PR DESCRIPTION
Summary: Fix multiple test failures
Commit diff: https://github.com/openjdk/jdk/commit/d06f3e7e28bd1baf00b903a7c6b2f18965e73311

Test Plan: all tests in runtime/appcds

Reviewed-by: yuleil, lingjun-cg

Issue: #402