### PR TITLE
[Backport] 8255349: Vector API issues on Big Endian

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -500,7 +500,7 @@ abstract class AbstractVector<E> extends Vector<E> {
     final <F>
     AbstractVector<F> defaultReinterpret(AbstractSpecies<F> rsp) {
         int blen = Math.max(this.bitSize(), rsp.vectorBitSize()) / Byte.SIZE;
-        ByteOrder bo = ByteOrder.LITTLE_ENDIAN;
+        ByteOrder bo = ByteOrder.nativeOrder();
         ByteBuffer bb = ByteBuffer.allocate(blen);
         this.intoByteBuffer(bb, 0, bo);
         VectorMask<F> m = rsp.maskAll(true);


### PR DESCRIPTION
Summary: [Backport] 8255349: Vector API issues on Big Endian

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/435