### PR TITLE
[Backport] 8255959: Timeouts in VectorConversion tests

### DIFF
--- a/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
@@ -31,9 +31,19 @@ import java.util.function.IntFunction;
 
 /**
  * @test
+ * @requires (os.arch != "ppc64") & (os.arch != "ppc64le")
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ *      Vector64ConversionTests
+ */
+
+/**
+ * @test VectorConversionHighTimeout
+ * @requires os.arch == "ppc64" | os.arch == "ppc64le"
+ * @modules jdk.incubator.vector
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run testng/othervm/timeout=1800  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      Vector64ConversionTests
  */
 


### PR DESCRIPTION
Summary: [Backport] 8255959: Timeouts in VectorConversion tests

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/454