### PR TITLE
[Backport] 8257806: Optimize x86 allTrue and anyTrue vector mask oper…

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -73,6 +73,10 @@ public:
   void get_elem(BasicType typ, Register dst, XMMRegister src, int elemindex);
   void get_elem(BasicType typ, XMMRegister dst, XMMRegister src, int elemindex, Register tmp = noreg, XMMRegister vtmp = xnoreg);
 
+  // vector test
+  void vectortest(int bt, int vlen, XMMRegister src1, XMMRegister src2,
+                  XMMRegister vtmp1 = xnoreg, XMMRegister vtmp2 = xnoreg);
+
   // blend
   void evpcmp(BasicType typ, KRegister kdmask, KRegister ksmask, XMMRegister src1, AddressLiteral adr, int comparison, int vector_len, Register scratch = rscratch1);
   void evpblend(BasicType typ, XMMRegister dst, KRegister kmask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1758,7 +1758,7 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
     case Op_VectorTest:
       if (UseSSE < 4) {
         return false; // Implementation limitation
-      } else if (size_in_bits < 128) {
+      } else if (size_in_bits < 32) {
         return false; // Implementation limitation
       } else if (size_in_bits == 512 && (VM_Version::supports_avx512bw() == false)) {
         return false; // Implementation limitation
@@ -7199,54 +7199,90 @@ instruct vabsnegD(vec dst, vec src, rRegI scratch) %{
 //------------------------------------- VectorTest --------------------------------------------
 
 #ifdef _LP64
-instruct vptest_alltrue(rRegI dst, legVec src1, legVec src2, rFlagsReg cr) %{
-  predicate(static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
+instruct vptest_alltrue_lt16(rRegI dst, legVec src1, legVec src2, legVec vtmp1, legVec vtmp2, rFlagsReg cr) %{
+  predicate(vector_length_in_bytes(n->in(1)) >= 4 &&
+            vector_length_in_bytes(n->in(1)) < 16 &&
+            static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
   match(Set dst (VectorTest src1 src2 ));
-  effect(KILL cr);
-  format %{ "vector_test $dst,$src1, $src2\t! using $cr as TEMP" %}
+  effect(TEMP vtmp1, TEMP vtmp2, KILL cr);
+  format %{ "vector_test $dst,$src1, $src2\t! using $vtmp1, $vtmp2 and $cr as TEMP" %}
   ins_encode %{
     int vlen = vector_length_in_bytes(this, $src1);
-    int vlen_enc = vector_length_encoding(vlen);
-    if (vlen <= 32) {
-      if (UseAVX == 0) {
-        assert(vlen <= 16, "required");
-        __ ptest($src1$$XMMRegister, $src2$$XMMRegister);
-      } else {
-        __ vptest($src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
-      }
-    } else {
-      KRegister ktmp = k2; // Use a hardcoded temp due to no k register allocation.
-      __ evpcmpeqb(ktmp, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
-      __ kortestql(ktmp, ktmp);
-    }
+    __ vectortest(BoolTest::overflow, vlen, $src1$$XMMRegister, $src2$$XMMRegister, $vtmp1$$XMMRegister, $vtmp2$$XMMRegister);
     __ setb(Assembler::carrySet, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
   %}
   ins_pipe( pipe_slow );
 %}
 
+instruct vptest_alltrue(rRegI dst, legVec src1, legVec src2, rFlagsReg cr) %{
+  predicate(vector_length_in_bytes(n->in(1)) >= 16 &&
+            static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::overflow);
+  match(Set dst (VectorTest src1 src2 ));
+  effect(KILL cr);
+  format %{ "vector_test $dst,$src1, $src2\t! using $cr as TEMP" %}
+  ins_encode %{
+    int vlen = vector_length_in_bytes(this, $src1);
+    __ vectortest(BoolTest::overflow, vlen, $src1$$XMMRegister, $src2$$XMMRegister); 
+    __ setb(Assembler::carrySet, $dst$$Register);
+    __ movzbl($dst$$Register, $dst$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct vptest_anytrue_lt16(rRegI dst, legVec src1, legVec src2, legVec vtmp, rFlagsReg cr) %{
+  predicate(vector_length_in_bytes(n->in(1)) >= 4 &&
+            vector_length_in_bytes(n->in(1)) < 16 &&
+            static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
+  match(Set dst (VectorTest src1 src2 ));
+  effect(TEMP vtmp, KILL cr);
+  format %{ "vector_test_any_true $dst,$src1,$src2\t! using $vtmp, $cr as TEMP" %}
+  ins_encode %{
+    int vlen = vector_length_in_bytes(this, $src1);
+    __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, $vtmp$$XMMRegister);
+    __ setb(Assembler::notZero, $dst$$Register);
+    __ movzbl($dst$$Register, $dst$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 instruct vptest_anytrue(rRegI dst, legVec src1, legVec src2, rFlagsReg cr) %{
-  predicate(static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
+  predicate(vector_length_in_bytes(n->in(1)) >= 16 &&
+            static_cast<const VectorTestNode*>(n)->get_predicate() == BoolTest::ne);
   match(Set dst (VectorTest src1 src2 ));
   effect(KILL cr);
   format %{ "vector_test_any_true $dst,$src1,$src2\t! using $cr as TEMP" %}
   ins_encode %{
     int vlen = vector_length_in_bytes(this, $src1);
-    int vlen_enc = vector_length_encoding(vlen);
-    if (vlen <= 32) {
-      if (UseAVX == 0) {
-        assert(vlen <= 16, "required");
-        __ ptest($src1$$XMMRegister, $src2$$XMMRegister);
-      } else {
-        __ vptest($src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
-      }
-    } else {
-      KRegister ktmp = k2; // Use a hardcoded temp due to no k register allocation.
-      __ evpcmpeqb(ktmp, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
-      __ ktestql(ktmp, ktmp);
-    }
+    __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister);
     __ setb(Assembler::notZero, $dst$$Register);
     __ movzbl($dst$$Register, $dst$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct cmpvptest_anytrue_lt16(rFlagsReg cr, legVec src1, legVec src2, immI_0 zero, legVec vtmp) %{
+  predicate(vector_length_in_bytes(n->in(1)->in(1)) >= 4 &&
+            vector_length_in_bytes(n->in(1)->in(1)) < 16 &&
+            static_cast<const VectorTestNode*>(n->in(1))->get_predicate() == BoolTest::ne);
+  match(Set cr (CmpI (VectorTest src1 src2) zero));
+  effect(TEMP vtmp);
+  format %{ "cmp_vector_test_any_true $src1,$src2\t! using $vtmp as TEMP" %}
+  ins_encode %{
+    int vlen = vector_length_in_bytes(this, $src1);
+    __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister, $vtmp$$XMMRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct cmpvptest_anytrue(rFlagsReg cr, legVec src1, legVec src2, immI_0 zero) %{
+  predicate(vector_length_in_bytes(n->in(1)->in(1)) >= 16 &&
+            static_cast<const VectorTestNode*>(n->in(1))->get_predicate() == BoolTest::ne);
+  match(Set cr (CmpI (VectorTest src1 src2) zero));
+  format %{ "cmp_vector_test_any_true $src1,$src2\t!" %}
+  ins_encode %{
+    int vlen = vector_length_in_bytes(this, $src1);
+    __ vectortest(BoolTest::ne, vlen, $src1$$XMMRegister, $src2$$XMMRegister);
   %}
   ins_pipe( pipe_slow );
 %}


### PR DESCRIPTION
…ations of Vector API

Summary: [Backport] 8257806: Optimize x86 allTrue and anyTrue vector mask operations of Vector API

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/455