### PR TITLE
[Backport] 8257537: [vector] Cleanup redundant bitwise cases on float…

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -665,8 +665,6 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                         v0.bOp(v1, (i, a, b) -> (double)Math.max(a, b));
                 case VECTOR_OP_MIN: return (v0, v1) ->
                         v0.bOp(v1, (i, a, b) -> (double)Math.min(a, b));
-                case VECTOR_OP_OR: return (v0, v1) ->
-                        v0.bOp(v1, (i, a, b) -> fromBits(toBits(a) | toBits(b)));
                 default: return null;
                 }}));
     }
@@ -2319,8 +2317,6 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                       toBits(v.rOp(MAX_OR_INF, (i, a, b) -> (double) Math.min(a, b)));
               case VECTOR_OP_MAX: return v ->
                       toBits(v.rOp(MIN_OR_INF, (i, a, b) -> (double) Math.max(a, b)));
-              case VECTOR_OP_OR: return v ->
-                      toBits(v.rOp((double)0, (i, a, b) -> fromBits(toBits(a) | toBits(b))));
               default: return null;
               }})));
     }
@@ -2336,13 +2332,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             = REDUCE_ID_IMPL.find(op, opc, (opc_) -> {
                 switch (opc_) {
                 case VECTOR_OP_ADD:
-                case VECTOR_OP_OR:
-                case VECTOR_OP_XOR:
                     return v -> v.broadcast(0);
                 case VECTOR_OP_MUL:
                     return v -> v.broadcast(1);
-                case VECTOR_OP_AND:
-                    return v -> v.broadcast(-1);
                 case VECTOR_OP_MIN:
                     return v -> v.broadcast(MAX_OR_INF);
                 case VECTOR_OP_MAX:

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -665,8 +665,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
                         v0.bOp(v1, (i, a, b) -> (float)Math.max(a, b));
                 case VECTOR_OP_MIN: return (v0, v1) ->
                         v0.bOp(v1, (i, a, b) -> (float)Math.min(a, b));
-                case VECTOR_OP_OR: return (v0, v1) ->
-                        v0.bOp(v1, (i, a, b) -> fromBits(toBits(a) | toBits(b)));
                 default: return null;
                 }}));
     }
@@ -2339,8 +2337,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
                       toBits(v.rOp(MAX_OR_INF, (i, a, b) -> (float) Math.min(a, b)));
               case VECTOR_OP_MAX: return v ->
                       toBits(v.rOp(MIN_OR_INF, (i, a, b) -> (float) Math.max(a, b)));
-              case VECTOR_OP_OR: return v ->
-                      toBits(v.rOp((float)0, (i, a, b) -> fromBits(toBits(a) | toBits(b))));
               default: return null;
               }})));
     }
@@ -2356,13 +2352,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
             = REDUCE_ID_IMPL.find(op, opc, (opc_) -> {
                 switch (opc_) {
                 case VECTOR_OP_ADD:
-                case VECTOR_OP_OR:
-                case VECTOR_OP_XOR:
                     return v -> v.broadcast(0);
                 case VECTOR_OP_MUL:
                     return v -> v.broadcast(1);
-                case VECTOR_OP_AND:
-                    return v -> v.broadcast(-1);
                 case VECTOR_OP_MIN:
                     return v -> v.broadcast(MAX_OR_INF);
                 case VECTOR_OP_MAX:

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -731,10 +731,6 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 case VECTOR_OP_URSHIFT: return (v0, v1) ->
                         v0.bOp(v1, (i, a, n) -> ($type$)((a & LSHR_SETUP_MASK) >>> n));
 #end[BITWISE]
-#if[FP]
-                case VECTOR_OP_OR: return (v0, v1) ->
-                        v0.bOp(v1, (i, a, b) -> fromBits(toBits(a) | toBits(b)));
-#end[FP]
                 default: return null;
                 }}));
     }
@@ -2836,10 +2832,6 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
               case VECTOR_OP_XOR: return v ->
                       toBits(v.rOp(($type$)0, (i, a, b) -> ($type$)(a ^ b)));
 #end[BITWISE]
-#if[FP]
-              case VECTOR_OP_OR: return v ->
-                      toBits(v.rOp(($type$)0, (i, a, b) -> fromBits(toBits(a) | toBits(b))));
-#end[FP]
               default: return null;
               }})));
     }
@@ -2855,13 +2847,17 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             = REDUCE_ID_IMPL.find(op, opc, (opc_) -> {
                 switch (opc_) {
                 case VECTOR_OP_ADD:
+#if[BITWISE]
                 case VECTOR_OP_OR:
                 case VECTOR_OP_XOR:
+#end[BITWISE]
                     return v -> v.broadcast(0);
                 case VECTOR_OP_MUL:
                     return v -> v.broadcast(1);
+#if[BITWISE]
                 case VECTOR_OP_AND:
                     return v -> v.broadcast(-1);
+#end[BITWISE]
                 case VECTOR_OP_MIN:
                     return v -> v.broadcast(MAX_OR_INF);
                 case VECTOR_OP_MAX:


### PR DESCRIPTION
…ing point vectors

Summary: [Backport] 8257537: [vector] Cleanup redundant bitwise cases on floating point vectors

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/452