### PR TITLE
[Backport] 8263125: During deoptimization vectors should reassign scalarized payload after all objects are reallocated.

### DIFF
--- a/src/hotspot/share/code/location.cpp
+++ b/src/hotspot/share/code/location.cpp
@@ -50,6 +50,7 @@ void Location::print_on(outputStream* st) const {
   case float_in_dbl: st->print(",float");      break;
   case dbl:          st->print(",double");     break;
   case addr:         st->print(",address");    break;
+  case vector:       st->print(",vector");     break;
   default:           st->print("Wrong location type %d", type());
   }
 }

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -170,7 +170,7 @@ Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, Regi
     assert(payload->is_object(), "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.as_string());
 #endif
   }
-  return Handle(THREAD, (oop)nullptr);
+  return Handle(THREAD, (oop)NULL);
 }
 
 instanceOop VectorSupport::allocate_vector(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ObjectValue* ov, TRAPS) {

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -150,16 +150,27 @@ Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* f
 }
 
 Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ScopeValue* payload, TRAPS) {
-  if (payload->is_location() &&
-      payload->as_LocationValue()->location().type() == Location::vector) {
-    // Vector value in an aligned adjacent tuple (1, 2, 4, 8, or 16 slots).
+  if (payload->is_location()) {
     Location location = payload->as_LocationValue()->location();
-    return allocate_vector_payload_helper(ik, fr, reg_map, location, THREAD); // safepoint
-  } else {
-    // Scalar-replaced boxed vector representation.
-    StackValue* value = StackValue::create_stack_value(fr, reg_map, payload);
-    return value->get_obj();
+    if (location.type() == Location::vector) {
+      // Vector value in an aligned adjacent tuple (1, 2, 4, 8, or 16 slots).
+      return allocate_vector_payload_helper(ik, fr, reg_map, location, THREAD); // safepoint
+    }
+#ifdef ASSERT
+    // Other payload values are: 'oop' type location and Scalar-replaced boxed vector representation.
+    // They will be processed in Deoptimization::reassign_fields() after all objects are reallocated.
+    else {
+      Location::Type loc_type = location.type();
+      assert(loc_type == Location::oop || loc_type == Location::narrowoop,
+             "expected 'oop'(%d) or 'narrowoop'(%d) types location but got: %d", Location::oop, Location::narrowoop, loc_type);
+    }
+  } else if (!payload->is_object()) {
+    stringStream ss;
+    payload->print_on(&ss);
+    assert(payload->is_object(), "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.as_string());
+#endif
   }
+  return Handle(THREAD, (oop)nullptr);
 }
 
 instanceOop VectorSupport::allocate_vector(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ObjectValue* ov, TRAPS) {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -204,7 +204,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   // relock objects if synchronization on them was eliminated.
 #if !INCLUDE_JVMCI
   if (DoEscapeAnalysis || EliminateNestedLocks) {
-    if (EliminateAllocations) {
+    if (EliminateAllocations || EliminateAutoBox || EnableVectorAggressiveReboxing) {
 #endif // INCLUDE_JVMCI
       assert (chunk->at(0)->scope() != NULL,"expect only compiled java frames");
       GrowableArray<ScopeValue*>* objects = chunk->at(0)->scope()->objects();
@@ -1088,16 +1088,35 @@ void Deoptimization::reassign_fields(frame* fr, RegisterMap* reg_map, GrowableAr
     Klass* k = java_lang_Class::as_Klass(sv->klass()->as_ConstantOopReadValue()->value()());
     Handle obj = sv->value();
     assert(obj.not_null() || realloc_failures, "reallocation was missed");
+#ifndef PRODUCT
     if (PrintDeoptimizationDetails) {
       tty->print_cr("reassign fields for object of type %s!", k->name()->as_C_string());
     }
+#endif // !PRODUCT
+
     if (obj.is_null()) {
       continue;
     }
 
 #ifdef COMPILER2
     if (EnableVectorSupport && VectorSupport::is_vector(k)) {
-      continue; // skip field reassignment for vectors
+      assert(sv->field_size() == 1, "%s not a vector", k->name()->as_C_string());
+      ScopeValue* payload = sv->field_at(0);
+      if (payload->is_location() &&
+          payload->as_LocationValue()->location().type() == Location::vector) {
+#ifndef PRODUCT
+        if (PrintDeoptimizationDetails) {
+          tty->print_cr("skip field reassignment for this vector - it should be assigned already");
+          if (Verbose) {
+            Handle obj = sv->value();
+            k->oop_print_on(obj(), tty);
+          }
+        }
+#endif // !PRODUCT
+        continue; // Such vector's value was already restored in VectorSupport::allocate_vector().
+      }
+      // Else fall-through to do assignment for scalar-replaced boxed vector representation
+      // which could be restored after vector object allocation.
     }
 #endif
     if (k->is_instance_klass()) {

--- a/src/hotspot/share/runtime/stackValue.cpp
+++ b/src/hotspot/share/runtime/stackValue.cpp
@@ -142,6 +142,7 @@ StackValue* StackValue::create_stack_value(const frame* fr, const RegisterMap* r
       return new StackValue(h);
     }
     case Location::addr: {
+      loc.print_on(tty);
       ShouldNotReachHere(); // both C1 and C2 now inline jsrs
     }
     case Location::normal: {
@@ -155,9 +156,11 @@ StackValue* StackValue::create_stack_value(const frame* fr, const RegisterMap* r
       return new StackValue();
     }
     case Location::vector: {
-      ShouldNotReachHere(); // should be handled by Deoptimization::realloc_objects()
+      loc.print_on(tty);
+      ShouldNotReachHere(); // should be handled by VectorSupport::allocate_vector()
     }
     default:
+      loc.print_on(tty);
       ShouldNotReachHere();
     }
 

--- a/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
+++ b/test/jdk/jdk/incubator/vector/Vector64ConversionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.function.IntFunction;
  * @requires (os.arch != "ppc64") & (os.arch != "ppc64le")
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=300  -XX:-TieredCompilation --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      Vector64ConversionTests
  */
 


### PR DESCRIPTION
Summary: Currently during deoptimization Vector's `payload` field values are restored during Vector reallocation.
But for scalar-replaced values (objects) this is not correct because that object could be re-allocated after allocation of this vector. Scalar-replaced `payload` should be restored during regular fields reassignment.

Test Plan: ci jtreg

Reviewed-by: JoshuaZhuwj

Issue: https://github.com/alibaba/dragonwell11/issues/465