### PR TITLE
[Backport] 8265317: [vector] assert(payload->is_object()) failed: expected 'object' value for scalar-replaced boxed vector but got: NULL

### DIFF
--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,17 +157,17 @@ Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, Regi
       return allocate_vector_payload_helper(ik, fr, reg_map, location, THREAD); // safepoint
     }
 #ifdef ASSERT
-    // Other payload values are: 'oop' type location and Scalar-replaced boxed vector representation.
+    // Other payload values are: 'oop' type location and scalar-replaced boxed vector representation.
     // They will be processed in Deoptimization::reassign_fields() after all objects are reallocated.
     else {
       Location::Type loc_type = location.type();
       assert(loc_type == Location::oop || loc_type == Location::narrowoop,
              "expected 'oop'(%d) or 'narrowoop'(%d) types location but got: %d", Location::oop, Location::narrowoop, loc_type);
     }
-  } else if (!payload->is_object()) {
+  } else if (!payload->is_object() && !payload->is_constant_oop()) {
     stringStream ss;
     payload->print_on(&ss);
-    assert(payload->is_object(), "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.as_string());
+    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.as_string());
 #endif
   }
   return Handle(THREAD, (oop)NULL);


### PR DESCRIPTION
Summary: vectorIntrinsics crashes with assert(payload->is_object()) failed: expected 'object' value for scalar-replaced boxed vector but got: NULL.
It doesn't take into account the case of a scalar-replaced instance with a constant field (null in this particular case).

Test Plan: ci jtreg

Reviewed-by: Zhuoren, JinZhonghui

Issue: https://github.com/alibaba/dragonwell11/issues/507