### PR TITLE
[GC] Fix activation mechanism for IOPrioritySizePolicy

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelArguments.cpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.cpp
@@ -66,9 +66,12 @@ void ParallelArguments::initialize() {
     if (FLAG_IS_DEFAULT(MaxHeapFreeRatio)) {
       FLAG_SET_DEFAULT(MaxHeapFreeRatio, 100);
     }
+#ifdef LINUX
+    // Auto-Enabled only on linux
     if (FLAG_IS_DEFAULT(UseIOPrioritySizePolicy)) {
       FLAG_SET_DEFAULT(UseIOPrioritySizePolicy, true);
     }
+#endif
   }
 
   if (UseIOPrioritySizePolicy && !UseAdaptiveSizePolicy) {


### PR DESCRIPTION
Summary: do not enable IOPrioritySizePolicy automatically on windows
Testing: jtreg
Reviewers: yyang, yude.lyd
Issue: https://github.com/dragonwell-project/dragonwell11/issues/875