### PR TITLE
[Misc] Revert "disable warnings as errors"

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -130,7 +130,6 @@ jobs:
           --with-jtreg=${{ steps.jtreg.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          --disable-warnings-as-errors
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&


### PR DESCRIPTION
Summary: This reverts commit 105a9b6c23999a6896a31adc8214f5c962d16764.

Testing: CICD

Reviewers: D-D-H, MaxXSoft

Issue: https://github.com/dragonwell-project/dragonwell11/issues/973